### PR TITLE
Move if compiling logic inside env Append/PopInstr functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,7 @@
 1. Rosetta Code examples
    1. Strip whitespace from a string/Top and tail
 1. Start putting examples on Rosetta Code
+1. Drop [] support for now, simplify @
 
 ### f6
 

--- a/TODO.md
+++ b/TODO.md
@@ -39,15 +39,12 @@
    1. tedious to add new files/builds
    1. blue.sh - run examples
    1. blue.sh - stop the process if a step errors out
-1. check env.AppendInstr usage to see if compiling check can be moved there
-   1. better placement of comments in asm (will be fixed by above)
-   1. same for env/latest PopInstr (condCall/loop in kernel)
 1. peephole doesn't run when compiling a word
 1. peephole - mov xxx, 0 -> xor xxx, xxx
 1. Rosetta Code examples
    1. Strip whitespace from a string/Top and tail
 1. Start putting examples on Rosetta Code
-1. Drop [] support for now, simplify @
+1. Drop [] support for now, simplify kernel for @
 
 ### f6
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,17 +7,14 @@
 1. import vs use - one brings in externs other all code from file
    1. link vs include? - use to determine how to build via dsl?
 1. better newline support when generating asm
-1. better placement of comments in asm
 1. outputs don't flow
 1. when importing, can drop the global decls from the imported env?
 1. continue to infer registers from word body
    1. if fully specified, validate
    1. infer during word fallthrough? whole program infer?
 1. validate needs to check for lingering refs/stack items
-1. check env.AppendInstr usage to see if compiling check can be moved there
 1. treat words with only decb more like resb
 1. mov edx, rax bug
-1. peephole doesn't run when compiling a word
 
 ### optimizations
 
@@ -28,7 +25,6 @@
 
 1. jmp vs call ret at tail of word
 1. jmp vs call noret word
-1. mov xxx, 0 -> xor xxx, xxx
 1. mov rxx, 1 -> xor exx, exx ; inc exx
 
 ## language
@@ -37,16 +33,23 @@
 
 # Targets
 
-### f7
+### f7 (current)
 
 1. Build process overhaul
    1. tedious to add new files/builds
    1. blue.sh - run examples
    1. blue.sh - stop the process if a step errors out
+1. check env.AppendInstr usage to see if compiling check can be moved there
+   1. better placement of comments in asm (will be fixed by above)
+1. peephole doesn't run when compiling a word
+1. peephole - mov xxx, 0 -> xor xxx, xxx
+1. Rosetta Code examples
+   1. Strip whitespace from a string/Top and tail
+1. Start putting examples on Rosetta Code
 
-### f6 (current)
+### f6
 
-1. README
+language and compiler improvements, v0.0.1
 
 ### f5
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,6 +41,7 @@
    1. blue.sh - stop the process if a step errors out
 1. check env.AppendInstr usage to see if compiling check can be moved there
    1. better placement of comments in asm (will be fixed by above)
+   1. same for env/latest PopInstr (condCall/loop in kernel)
 1. peephole doesn't run when compiling a word
 1. peephole - mov xxx, 0 -> xor xxx, xxx
 1. Rosetta Code examples

--- a/asm.go
+++ b/asm.go
@@ -83,7 +83,7 @@ type AsmCommentInstr struct {
 }
 
 func (i *AsmCommentInstr) String() string {
-	return fmt.Sprintf("\n; %s", i.Comment)
+	return fmt.Sprintf("\n; %s\n", i.Comment)
 }
 
 type AsmResInstr struct {

--- a/env.go
+++ b/env.go
@@ -158,7 +158,7 @@ func (e *Environment) DeclWord(word *Word) {
 	e.ValidateRegisterRefs(word.Outputs)
 
 	e.AppendWord(word)
-	e.AppendInstrs([]Instr{
+	e.AppendCodeBufInstrs([]Instr{
 		&CommentInstr{Comment: word.DeclString()},
 		&DeclWordInstr{Word: word},
 	})
@@ -290,12 +290,28 @@ func (e *Environment) PopAsmInstr() AsmInstr {
 	return instr
 }
 
-func (e *Environment) AppendInstr(i Instr) {
+func (e *Environment) AppendCodeBufInstr(i Instr) {
 	e.CodeBuf = append(e.CodeBuf, i)
 }
 
-func (e *Environment) AppendInstrs(i []Instr) {
+func (e *Environment) AppendCodeBufInstrs(i []Instr) {
 	e.CodeBuf = append(e.CodeBuf, i...)
+}
+
+func (e *Environment) AppendInstr(i Instr) {
+	if e.Compiling {
+		e.Dictionary.Latest.AppendInstr(i)
+	} else {
+		e.CodeBuf = append(e.CodeBuf, i)
+	}
+}
+
+func (e *Environment) AppendInstrs(i []Instr) {
+	if e.Compiling {
+		e.Dictionary.Latest.AppendInstrs(i)
+	} else {
+		e.CodeBuf = append(e.CodeBuf, i...)
+	}
 }
 
 func (e *Environment) OptimizeInstrs() {
@@ -333,7 +349,7 @@ func (e *Environment) SuggestSection(section string) {
 		return
 	}
 
-	e.AppendInstr(&SectionInstr{Info: section})
+	e.AppendCodeBufInstr(&SectionInstr{Info: section})
 	e.Section = section
 }
 

--- a/env.go
+++ b/env.go
@@ -254,9 +254,9 @@ func (e *Environment) ParseNextWord() bool {
 		log.Fatal("Did not find ", name)
 	}
 
-	if !e.Compiling {
-		e.AppendInstrs(instrs)
+	e.AppendInstrs(instrs)
 
+	if !e.Compiling {
 		if shouldOptimize {
 			e.OptimizeInstrs()
 		}
@@ -265,8 +265,6 @@ func (e *Environment) ParseNextWord() bool {
 			clobbers &= ^e.Dictionary.Latest.Registers
 			e.Dictionary.Latest.Clobbers |= clobbers
 		}
-
-		e.Dictionary.Latest.AppendInstrs(instrs)
 	}
 
 	return true

--- a/env.go
+++ b/env.go
@@ -316,7 +316,7 @@ func (e *Environment) OptimizeInstrs() {
 	e.CodeBuf = PerformPeepholeOptimizationsAtEnd(e.CodeBuf)
 }
 
-func (e *Environment) PopInstr() Instr {
+func (e *Environment) PopCodeBufInstr() Instr {
 	last := len(e.CodeBuf) - 1
 	instr := e.CodeBuf[last]
 	e.CodeBuf = e.CodeBuf[:last]
@@ -324,14 +324,12 @@ func (e *Environment) PopInstr() Instr {
 	return instr
 }
 
-func (e *Environment) Pop2Instrs() (Instr, Instr) {
-	codeBufLen := len(e.CodeBuf)
-	second := e.CodeBuf[codeBufLen-2]
-	first := e.CodeBuf[codeBufLen-1]
+func (e *Environment) PopInstr() Instr {
+	if e.Compiling {
+		return e.Dictionary.Latest.PopInstr()
+	}
 
-	e.CodeBuf = e.CodeBuf[:codeBufLen-2]
-
-	return second, first
+	return e.PopCodeBufInstr()
 }
 
 func (e *Environment) SuggestSection(section string) {

--- a/kernel.go
+++ b/kernel.go
@@ -44,7 +44,7 @@ func KernelExtern(env *Environment) {
 
 func KernelLatest(env *Environment) {
 	latest := env.Dictionary.Latest
-	latest.AppendInstr(&RefWordInstr{Word: latest})
+	env.AppendInstr(&RefWordInstr{Word: latest})
 }
 
 func KernelSemi(env *Environment) {
@@ -191,11 +191,11 @@ func KernelTick(env *Environment) {
 	}
 
 	instr := &RefWordInstr{Word: word}
-	// TODO won't work when not compiling
-	env.Dictionary.Latest.AppendInstr(instr)
+	env.AppendInstr(instr)
 }
 
 // TODO when migrating AppendInstr calls drop latest from the cond/loop names
+// TODO check for PopInstr usage on env, add compile check like AppendInstr
 func condCallLatest(env *Environment, jmp string) {
 	latest := env.Dictionary.Latest
 	refWord := latest.PopInstr().(*RefWordInstr)
@@ -258,7 +258,7 @@ func KernelLBracket(env *Environment) {
 		log.Fatal("[ expects a word before ]")
 	}
 
-	env.Dictionary.Latest.AppendInstr(&BracketInstr{
+	env.AppendInstr(&BracketInstr{
 		Value:        strings.Join(parts, " "),
 		Replacements: replacements,
 	})
@@ -277,7 +277,7 @@ func KernelSQuote(env *Environment) {
 		str = str[1:]
 	}
 
-	env.Dictionary.Latest.AppendInstr(&AsciiStrInstr{Str: str})
+	env.AppendInstr(&AsciiStrInstr{Str: str})
 }
 
 func buildRegisterRef(rawRef string) *RegisterRef {

--- a/kernel.go
+++ b/kernel.go
@@ -195,6 +195,7 @@ func KernelTick(env *Environment) {
 	env.Dictionary.Latest.AppendInstr(instr)
 }
 
+// TODO when migrating AppendInstr calls drop latest from the cond/loop names
 func condCallLatest(env *Environment, jmp string) {
 	latest := env.Dictionary.Latest
 	refWord := latest.PopInstr().(*RefWordInstr)

--- a/language/examples/echo.asm
+++ b/language/examples/echo.asm
@@ -6,21 +6,25 @@ global bye
 global die
 
 ; : syscall ( num:eax -- result:eax )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : die ( err:eax -- noret )
+
 __blue_3630339793_0:
 	neg eax
 	mov edi, eax
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
@@ -28,11 +32,13 @@ __blue_1911791459_0:
 global _start
 
 ; : syscall3 ( edi edx esi num:eax -- result:eax )
+
 __blue_1472650507_0:
 	call __blue_4057121178_0
 	ret
 
 ; : unwrap ( result:eax -- value:eax )
+
 __blue_4055961022_0:
 	cmp eax, 0
 	jge __blue_2157056155_0
@@ -42,12 +48,14 @@ __blue_2157056155_0:
 	ret
 
 ; : read ( fd len buf -- result )
+
 __blue_3470762949_0:
 	mov eax, 0
 	call __blue_1472650507_0
 	ret
 
 ; : write ( fd len buf -- result )
+
 __blue_3190202204_0:
 	mov eax, 1
 	call __blue_1472650507_0
@@ -56,10 +64,12 @@ __blue_3190202204_0:
 section .bss
 
 ; 1024 resb buf
+
 __blue_1926597602_0: resb 1024
 section .text
 
 ; : read ( fd -- read )
+
 __blue_3470762949_1:
 	mov esi, __blue_1926597602_0
 	mov edx, 1024
@@ -68,6 +78,7 @@ __blue_3470762949_1:
 	ret
 
 ; : write ( len fd -- wrote )
+
 __blue_3190202204_1:
 	mov esi, __blue_1926597602_0
 	call __blue_3190202204_0
@@ -75,8 +86,11 @@ __blue_3190202204_1:
 	ret
 
 ;  TODO compare read/write bytes for exit status
+
 ;  TODO loop until read 0
+
 ; : _start ( -- noret )
+
 _start:
 	mov edi, 0
 	call __blue_3470762949_1

--- a/language/examples/fib_test.asm
+++ b/language/examples/fib_test.asm
@@ -1,10 +1,12 @@
 
 ; : fib ( nth:ecx -- result:edi )
+
 __blue_3169096246_0:
 	mov edi, 0
 	mov eax, 1
 
 ; : compute ( times:ecx accum:eax scratch:edi -- result:edi )
+
 __blue_1147400058_0:
 	xadd eax, edi
 	loop __blue_1147400058_0
@@ -17,21 +19,25 @@ global bye
 global die
 
 ; : syscall ( num:eax -- result:eax )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : die ( err:eax -- noret )
+
 __blue_3630339793_0:
 	neg eax
 	mov edi, eax
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
@@ -39,13 +45,16 @@ __blue_1911791459_0:
 global _start
 
 ;  TODO exit with the test # that failed
+
 ; : test.failure ( -- )
+
 __blue_1516647173_0:
 	mov edi, 1
 	call __blue_3454868101_0
 	ret
 
 ; : test= ( actual:edi expected:eax -- )
+
 __blue_2636330760_0:
 	cmp eax, edi
 	je __blue_2157056155_0
@@ -55,6 +64,7 @@ __blue_2157056155_0:
 	ret
 
 ; : _start ( -- noret )
+
 _start:
 	mov ecx, 1
 	call __blue_3169096246_0

--- a/language/examples/rosettacode/clear_the_screen.asm
+++ b/language/examples/rosettacode/clear_the_screen.asm
@@ -2,33 +2,39 @@
 global _start
 
 ; : syscall ( num:eax -- result:eax )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
 
 ; : write ( buf:esi len:edx fd:edi -- )
+
 __blue_3190202204_0:
 	mov eax, 1
 	call __blue_4057121178_0
 	ret
 
 ; : print ( buf len -- )
+
 __blue_372738696_0:
 	mov edi, 1
 	call __blue_3190202204_0
 	ret
 
 ; : clear-screen ( -- )
+
 __blue_1703174329_0:
 	jmp __blue_1223589535_0
 
@@ -49,6 +55,7 @@ __blue_1223589535_0:
 	ret
 
 ; : _start ( -- noret )
+
 _start:
 	call __blue_1703174329_0
 	call __blue_1911791459_0

--- a/language/examples/rosettacode/commandline_args.asm
+++ b/language/examples/rosettacode/commandline_args.asm
@@ -2,27 +2,32 @@
 global _start
 
 ; : syscall ( num:eax -- result:eax | rcx )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
 
 ; : die ( err:eax -- noret )
+
 __blue_3630339793_0:
 	neg eax
 	mov edi, eax
 	call __blue_3454868101_0
 
 ; : unwrap ( result:eax -- value:eax )
+
 __blue_4055961022_0:
 	cmp eax, 0
 	jge __blue_2157056155_0
@@ -32,11 +37,13 @@ __blue_2157056155_0:
 	ret
 
 ; : ordie ( result -- )
+
 __blue_1614081290_0:
 	call __blue_4055961022_0
 	ret
 
 ; : write ( buf:esi len:edx fd:edi -- )
+
 __blue_3190202204_0:
 	mov eax, 1
 	call __blue_4057121178_0
@@ -44,12 +51,14 @@ __blue_3190202204_0:
 	ret
 
 ; : print ( buf len -- )
+
 __blue_372738696_0:
 	mov edi, 1
 	call __blue_3190202204_0
 	ret
 
 ; : newline ( -- )
+
 __blue_4281549323_0:
 	jmp __blue_1223589535_0
 
@@ -64,12 +73,14 @@ __blue_1223589535_0:
 	ret
 
 ; : println ( buf len -- )
+
 __blue_415234214_0:
 	call __blue_372738696_0
 	call __blue_4281549323_0
 	ret
 
 ; : find0 ( start:rsi -- end:rsi )
+
 __blue_1805780446_0:
 	lodsb
 	cmp al, 0
@@ -80,6 +91,7 @@ __blue_2157056155_1:
 	ret
 
 ; : cstrlen ( str:rdi -- len:rsi )
+
 __blue_1939608060_0:
 	mov rsi, rdi
 	call __blue_1805780446_0
@@ -88,6 +100,7 @@ __blue_1939608060_0:
 	ret
 
 ; : cstr>str ( cstr:rdx -- str:rsi len:rdx )
+
 __blue_3207375596_0:
 	mov rdi, rdx
 	call __blue_1939608060_0
@@ -95,16 +108,19 @@ __blue_3207375596_0:
 	ret
 
 ; : print-arg ( arg -- )
+
 __blue_2701174125_0:
 	call __blue_3207375596_0
 	call __blue_415234214_0
 	ret
 
 ; : _start ( rsp -- noret )
+
 _start:
 	mov rcx, [rsp]
 
 ; : print-args ( argc:rcx argv:rsp -- noret )
+
 __blue_2449731130_0:
 	add rsp, 8
 	mov rdx, [rsp]

--- a/language/examples/rosettacode/create_file.asm
+++ b/language/examples/rosettacode/create_file.asm
@@ -2,27 +2,32 @@
 global _start
 
 ; : syscall ( num:eax -- result:eax )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
 
 ; : die ( err:eax -- noret )
+
 __blue_3630339793_0:
 	neg eax
 	mov edi, eax
 	call __blue_3454868101_0
 
 ; : unwrap ( result:eax -- value:eax )
+
 __blue_4055961022_0:
 	cmp eax, 0
 	jge __blue_2157056155_0
@@ -32,11 +37,13 @@ __blue_2157056155_0:
 	ret
 
 ; : ordie ( result -- )
+
 __blue_1614081290_0:
 	call __blue_4055961022_0
 	ret
 
 ; : open ( pathname:edi flags:esi mode:edx -- fd:eax )
+
 __blue_3546203337_0:
 	mov eax, 2
 	call __blue_4057121178_0
@@ -44,6 +51,7 @@ __blue_3546203337_0:
 	ret
 
 ; : close ( fd:edi -- )
+
 __blue_667630371_0:
 	mov eax, 3
 	call __blue_4057121178_0
@@ -51,6 +59,7 @@ __blue_667630371_0:
 	ret
 
 ; : mkdir ( pathname:edi mode:esi -- )
+
 __blue_2883839448_0:
 	mov eax, 83
 	call __blue_4057121178_0
@@ -58,6 +67,7 @@ __blue_2883839448_0:
 	ret
 
 ; : create-file ( pathname -- )
+
 __blue_3101971046_0:
 	mov edx, 416
 	mov esi, 577
@@ -67,12 +77,14 @@ __blue_3101971046_0:
 	ret
 
 ; : make-directory ( pathname -- )
+
 __blue_2358895277_0:
 	mov esi, 488
 	call __blue_2883839448_0
 	ret
 
 ; : create-output-file ( -- )
+
 __blue_2468950182_0:
 	jmp __blue_1223589535_0
 
@@ -95,6 +107,7 @@ __blue_1223589535_0:
 	ret
 
 ; : make-docs-directory ( -- )
+
 __blue_2374470879_0:
 	jmp __blue_1223589535_1
 
@@ -111,6 +124,7 @@ __blue_1223589535_1:
 	ret
 
 ; : _start ( -- noret )
+
 _start:
 	call __blue_2468950182_0
 	call __blue_2374470879_0

--- a/language/examples/rosettacode/fibonacci.asm
+++ b/language/examples/rosettacode/fibonacci.asm
@@ -1,10 +1,12 @@
 
 ; : fib ( nth:ecx -- result:edi )
+
 __blue_3169096246_0:
 	mov edi, 0
 	mov eax, 1
 
 ; : compute ( times:ecx accum:eax scratch:edi -- result:edi )
+
 __blue_1147400058_0:
 	xadd eax, edi
 	loop __blue_1147400058_0

--- a/language/examples/rosettacode/hello_world.asm
+++ b/language/examples/rosettacode/hello_world.asm
@@ -2,33 +2,39 @@
 global _start
 
 ; : syscall ( num:eax -- result:eax )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
 
 ; : write ( buf:esi len:edx fd:edi -- )
+
 __blue_3190202204_0:
 	mov eax, 1
 	call __blue_4057121178_0
 	ret
 
 ; : print ( buf len -- )
+
 __blue_372738696_0:
 	mov edi, 1
 	call __blue_3190202204_0
 	ret
 
 ; : greet ( -- )
+
 __blue_4213039946_0:
 	jmp __blue_1223589535_0
 
@@ -55,6 +61,7 @@ __blue_1223589535_0:
 	ret
 
 ; : _start ( -- noret )
+
 _start:
 	call __blue_4213039946_0
 	call __blue_1911791459_0

--- a/language/examples/rosettacode/program_name.asm
+++ b/language/examples/rosettacode/program_name.asm
@@ -2,33 +2,39 @@
 global _start
 
 ; : syscall ( num:eax -- result:eax )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
 
 ; : write ( buf:esi len:edx fd:edi -- )
+
 __blue_3190202204_0:
 	mov eax, 1
 	call __blue_4057121178_0
 	ret
 
 ; : print ( buf len -- )
+
 __blue_372738696_0:
 	mov edi, 1
 	call __blue_3190202204_0
 	ret
 
 ; : newline ( -- )
+
 __blue_4281549323_0:
 	jmp __blue_1223589535_0
 
@@ -43,12 +49,14 @@ __blue_1223589535_0:
 	ret
 
 ; : println ( buf len -- )
+
 __blue_415234214_0:
 	call __blue_372738696_0
 	call __blue_4281549323_0
 	ret
 
 ; : find0 ( start:rsi -- end:rsi )
+
 __blue_1805780446_0:
 	lodsb
 	cmp al, 0
@@ -59,6 +67,7 @@ __blue_2157056155_0:
 	ret
 
 ; : cstrlen ( str:rdi -- len:rsi )
+
 __blue_1939608060_0:
 	mov rsi, rdi
 	call __blue_1805780446_0
@@ -67,6 +76,7 @@ __blue_1939608060_0:
 	ret
 
 ; : cstr>str ( cstr:rdx -- str:rsi len:rdx )
+
 __blue_3207375596_0:
 	mov rdi, rdx
 	call __blue_1939608060_0
@@ -74,17 +84,20 @@ __blue_3207375596_0:
 	ret
 
 ; : print-arg ( arg -- )
+
 __blue_2701174125_0:
 	call __blue_3207375596_0
 	call __blue_415234214_0
 	ret
 
 ; : arg0 ( rsp -- rsp )
+
 __blue_1611286325_0:
 	add rsp, 8
 	ret
 
 ; : _start ( rsp -- noret )
+
 _start:
 	add rsp, 8
 	mov rdx, [rsp]

--- a/language/examples/rosettacode/read_entire_file.asm
+++ b/language/examples/rosettacode/read_entire_file.asm
@@ -2,27 +2,32 @@
 global _start
 
 ; : syscall ( num:eax -- result:eax )
+
 __blue_4057121178_0:
 	syscall
 	ret
 
 ; : exit ( status:edi -- noret )
+
 __blue_3454868101_0:
 	mov eax, 60
 	call __blue_4057121178_0
 
 ; : bye ( -- noret )
+
 __blue_1911791459_0:
 	mov edi, 0
 	call __blue_3454868101_0
 
 ; : die ( err:eax -- noret )
+
 __blue_3630339793_0:
 	neg eax
 	mov edi, eax
 	call __blue_3454868101_0
 
 ; : unwrap ( result:eax -- value:eax )
+
 __blue_4055961022_0:
 	cmp eax, 0
 	jge __blue_2157056155_0
@@ -32,11 +37,13 @@ __blue_2157056155_0:
 	ret
 
 ; : ordie ( result -- )
+
 __blue_1614081290_0:
 	call __blue_4055961022_0
 	ret
 
 ; : open ( pathname:edi flags:esi -- fd:eax )
+
 __blue_3546203337_0:
 	mov eax, 2
 	call __blue_4057121178_0
@@ -44,6 +51,7 @@ __blue_3546203337_0:
 	ret
 
 ; : close ( fd:edi -- )
+
 __blue_667630371_0:
 	mov eax, 3
 	call __blue_4057121178_0
@@ -53,14 +61,18 @@ __blue_667630371_0:
 section .bss
 
 ; 48 resb stat_buf
+
 __blue_1200943365_0: resb 48
 ; 8 resb file-size
+
 __blue_1140937235_0: resb 8
 ; 88 resb padding
+
 __blue_2157316278_0: resb 88
 section .text
 
 ; : fstat ( fd:edi buf:esi -- )
+
 __blue_1508683483_0:
 	mov eax, 5
 	call __blue_4057121178_0
@@ -68,6 +80,7 @@ __blue_1508683483_0:
 	ret
 
 ; : mmap ( fd:r8d len:esi addr:edi off:r9d prot:edx flags:r10d -- buf:eax )
+
 __blue_776417966_0:
 	mov eax, 9
 	call __blue_4057121178_0
@@ -75,6 +88,7 @@ __blue_776417966_0:
 	ret
 
 ; : munmap ( addr:edi len:esi -- )
+
 __blue_287864331_0:
 	mov eax, 11
 	call __blue_4057121178_0
@@ -84,10 +98,12 @@ __blue_287864331_0:
 section .bss
 
 ; 1 resd fd
+
 __blue_1763898183_0: resd 1
 section .text
 
 ; : open-file ( pathname:edi -- )
+
 __blue_3225053210_0:
 	mov esi, 0
 	call __blue_3546203337_0
@@ -95,6 +111,7 @@ __blue_3225053210_0:
 	ret
 
 ; : read-file-size ( -- )
+
 __blue_1039529288_0:
 	mov esi, __blue_1200943365_0
 	mov edi, [__blue_1763898183_0]
@@ -102,6 +119,7 @@ __blue_1039529288_0:
 	ret
 
 ; : map-file ( fd len -- buf )
+
 __blue_2864669986_0:
 	mov r10d, 2
 	mov edx, 1
@@ -111,6 +129,7 @@ __blue_2864669986_0:
 	ret
 
 ; : map-file ( -- buf )
+
 __blue_2864669986_1:
 	mov esi, [__blue_1140937235_0]
 	mov r8d, [__blue_1763898183_0]
@@ -118,18 +137,21 @@ __blue_2864669986_1:
 	ret
 
 ; : unmap-file ( buf -- )
+
 __blue_255719461_0:
 	mov esi, [__blue_1140937235_0]
 	call __blue_287864331_0
 	ret
 
 ; : close-file ( -- )
+
 __blue_2161677324_0:
 	mov edi, [__blue_1763898183_0]
 	call __blue_667630371_0
 	ret
 
 ; : open-this-file ( -- )
+
 __blue_822887505_0:
 	jmp __blue_1223589535_0
 
@@ -162,12 +184,14 @@ __blue_1223589535_0:
 	call __blue_3225053210_0
 	ret
 
-;  do something ...
 ; : _start ( -- noret )
+
 _start:
 	call __blue_822887505_0
 	call __blue_1039529288_0
 	call __blue_2864669986_1
+
+;  do something ...
 	mov edi, eax
 	call __blue_255719461_0
 	call __blue_2161677324_0

--- a/main.go
+++ b/main.go
@@ -96,8 +96,8 @@ var registers = map[string]int{
 	"esi": esi,
 	"edi": edi,
 
-	"r8d": r8d,
-	"r9d": r9d,
+	"r8d":  r8d,
+	"r9d":  r9d,
 	"r10d": r10d,
 	"r11d": r11d,
 	"r12d": r12d,
@@ -114,8 +114,8 @@ var registers = map[string]int{
 	"rsi": rsi,
 	"rdi": rdi,
 
-	"r8": r8,
-	"r9": r9,
+	"r8":  r8,
+	"r9":  r9,
 	"r10": r10,
 	"r11": r11,
 	"r12": r12,


### PR DESCRIPTION
Fixes several issues with some words not working properly when compiling or not. Also allows comments to be placed inside word declarations instead of always above. Had to add a newline after all comments so they did not run into the next statement. Will defer dealing with that until the asm output becomes a focus (see TODO.md)