### PR TITLE
Remove explicit ret mnemonic in kernel

### DIFF
--- a/asm.go
+++ b/asm.go
@@ -51,6 +51,13 @@ func (i *AsmCallInstr) String() string {
 	return fmt.Sprintf("\tcall %s\n", i.Label)
 }
 
+type AsmRetInstr struct {
+}
+
+func (i *AsmRetInstr) String() string {
+	return fmt.Sprintf("\tret\n")
+}
+
 type AsmNoOperandInstr struct {
 	Mnemonic string
 }

--- a/env.go
+++ b/env.go
@@ -242,10 +242,8 @@ func instrsForWord(word *Word) []Instr {
 	}
 
 	lastIdx := len(word.Code)
-	if instr, x8664 := word.Code[lastIdx-1].(*X8664Instr); x8664 {
-		if instr.Mnemonic == "ret" {
-			lastIdx -= 1
-		}
+	if _, isRet := word.Code[lastIdx-1].(*RetInstr); isRet {
+		lastIdx -= 1
 	}
 
 	return word.Code[:lastIdx]

--- a/instr.go
+++ b/instr.go
@@ -70,8 +70,13 @@ type CallInstr struct{}
 func (i *CallInstr) Run(env *Environment, context *RunContext) {
 	target := context.PopInput()
 
-	// TODO AsmCallInstr -> AsmUnaryInstr
 	env.AppendAsmInstr(&AsmCallInstr{Label: target})
+}
+
+type RetInstr struct{}
+
+func (i *RetInstr) Run(env *Environment, context *RunContext) {
+	env.AppendAsmInstr(&AsmRetInstr{})
 }
 
 type CallWordInstr struct {

--- a/kernel.go
+++ b/kernel.go
@@ -56,7 +56,7 @@ func KernelSemi(env *Environment) {
 				Word:      latest,
 				Direction: FlowDirection_Output,
 			},
-			&X8664Instr{Mnemonic: "ret"},
+			&RetInstr{},
 		})
 	}
 


### PR DESCRIPTION
Need to prevent explicit x8664 instructions from being generated in the kernel.