### PR TITLE
Indirect clobbers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,8 +45,6 @@
 
 1. need to support var1 @ var2 ! - @! with clobber support
    1. movs?
-1. clobber support for indirect register usage
-   1. consider fallthrough words
 
 ### f7
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 1. continue to infer registers from word body
    1. if fully specified, validate
    1. infer during word fallthrough? whole program infer?
+   1. needs x8664 "words" to have register definitions
 1. validate needs to check for lingering refs/stack items
    1. some fatal logs exist
 1. treat words with only decb more like resb
@@ -42,8 +43,8 @@
 
 ### f8
 
-1. allow addresses in stack refs
 1. need to support var1 @ var2 ! - @! with clobber support
+   1. movs?
 1. clobber support for indirect register usage
    1. consider fallthrough words
 

--- a/clobbers.go
+++ b/clobbers.go
@@ -1,6 +1,6 @@
 package main
 
-func UpdateClobbers(clobberSet uint, registerSet uint, indirectRegisterSet uint) uint {
+func UpdatedClobbers(clobberSet uint, registerSet uint, indirectRegisterSet uint) uint {
 	clobberSet |= indirectRegisterSet
 	clobberSet &= ^registerSet
 

--- a/clobbers.go
+++ b/clobbers.go
@@ -1,6 +1,7 @@
 package main
 
 func UpdateClobbers(clobberSet uint, registerSet uint, indirectRegisterSet uint) uint {
+	clobberSet |= indirectRegisterSet
 	clobberSet &= ^registerSet
 
 	return clobberSet

--- a/clobbers.go
+++ b/clobbers.go
@@ -1,0 +1,7 @@
+package main
+
+func UpdateClobbers(clobberSet uint, registerSet uint, indirectRegisterSet uint) uint {
+	clobberSet &= ^registerSet
+
+	return clobberSet
+}

--- a/clobbers_test.go
+++ b/clobbers_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestIsOkWithNoClobbersOrRegisters(t *testing.T) {
 	expected := uint(0)
-	clobbers := UpdateClobbers(expected, 0, 0)
+	clobbers := UpdatedClobbers(expected, 0, 0)
 
 	if clobbers != expected {
 		t.Fatal("Expected clobbers to be empty")
@@ -15,7 +15,7 @@ func TestIsOkWithNoClobbersOrRegisters(t *testing.T) {
 
 func TestDoesNotChangeClobbersIfNoRegisters(t *testing.T) {
 	expected := uint(1 << rax)
-	clobbers := UpdateClobbers(expected, 0, 0)
+	clobbers := UpdatedClobbers(expected, 0, 0)
 
 	if clobbers != expected {
 		t.Fatal("Expected clobbers not to change")
@@ -25,7 +25,7 @@ func TestDoesNotChangeClobbersIfNoRegisters(t *testing.T) {
 func TestClobbersDoesNotIncludeSpecifiedRegisters(t *testing.T) {
 	expected := uint(0)
 	specifiedRegisters := uint(1 << rax)
-	clobbers := UpdateClobbers(specifiedRegisters, specifiedRegisters, 0)
+	clobbers := UpdatedClobbers(specifiedRegisters, specifiedRegisters, 0)
 
 	if clobbers != expected {
 		t.Fatal("Expected clobbers not to include specified registers")
@@ -35,7 +35,7 @@ func TestClobbersDoesNotIncludeSpecifiedRegisters(t *testing.T) {
 func TestClobbersIncludeNonSpecifiedRegisters(t *testing.T) {
 	expected := uint(1 << rcx)
 	specifiedRegisters := uint(1 << rax)
-	clobbers := UpdateClobbers(expected|specifiedRegisters, specifiedRegisters, 0)
+	clobbers := UpdatedClobbers(expected|specifiedRegisters, specifiedRegisters, 0)
 
 	if clobbers != expected {
 		t.Fatal("Expected clobbers not to include specified registers")
@@ -46,7 +46,7 @@ func TestClobbersIncludeIndirectRegisters(t *testing.T) {
 	expected := uint(1 << rcx)
 	specifiedRegisters := uint(1 << rax)
 	indirectRegisters := uint(1 << rcx)
-	clobbers := UpdateClobbers(0, specifiedRegisters, indirectRegisters)
+	clobbers := UpdatedClobbers(0, specifiedRegisters, indirectRegisters)
 
 	if clobbers != expected {
 		t.Fatal("Expected clobbers to include indirect registers")
@@ -57,7 +57,7 @@ func TestClobbersDoesNotIncludeIndirectRegistersThatAreAlsoSpecified(t *testing.
 	expected := uint(0)
 	specifiedRegisters := uint(1<<rax | 1<<rcx)
 	indirectRegisters := uint(1 << rcx)
-	clobbers := UpdateClobbers(0, specifiedRegisters, indirectRegisters)
+	clobbers := UpdatedClobbers(0, specifiedRegisters, indirectRegisters)
 
 	if clobbers != expected {
 		t.Fatal("Expected clobbers not to include indirect registers that are also specified")

--- a/clobbers_test.go
+++ b/clobbers_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIsOkWithNoClobbersOrRegisters(t *testing.T) {
+	expected := uint(0)
+	clobbers := UpdateClobbers(expected, 0, 0)
+
+	if clobbers != expected {
+		t.Fatal("Expected clobbers to be empty")
+	}
+}
+
+func TestDoesNotChangeClobbersIfNoRegisters(t *testing.T) {
+	expected := uint(1 << rax)
+	clobbers := UpdateClobbers(expected, 0, 0)
+
+	if clobbers != expected {
+		t.Fatal("Expected clobbers not to change")
+	}
+}
+
+func TestClobbersDoesNotIncludeSpecifiedRegisters(t *testing.T) {
+	expected := uint(0)
+	specifiedRegisters := uint(1 << rax)
+	clobbers := UpdateClobbers(specifiedRegisters, specifiedRegisters, 0)
+
+	if clobbers != expected {
+		t.Fatal("Expected clobbers not to include specified registers")
+	}
+}
+
+func TestClobbersIncludeNonSpecifiedRegisters(t *testing.T) {
+	expected := uint(1 << rcx)
+	specifiedRegisters := uint(1 << rax)
+	clobbers := UpdateClobbers(expected|specifiedRegisters, specifiedRegisters, 0)
+
+	if clobbers != expected {
+		t.Fatal("Expected clobbers not to include specified registers")
+	}
+}
+
+func TestClobbersIncludeIndirectRegisters(t *testing.T) {
+	expected := uint(1 << rcx)
+	specifiedRegisters := uint(1 << rax)
+	indirectRegisters := uint(1 << rcx)
+	clobbers := UpdateClobbers(0, specifiedRegisters, indirectRegisters)
+
+	if clobbers != expected {
+		t.Fatal("Expected clobbers to include indirect registers")
+	}
+}
+
+func TestClobbersDoesNotIncludeIndirectRegistersThatAreAlsoSpecified(t *testing.T) {
+	expected := uint(0)
+	specifiedRegisters := uint(1<<rax | 1<<rcx)
+	indirectRegisters := uint(1 << rcx)
+	clobbers := UpdateClobbers(0, specifiedRegisters, indirectRegisters)
+
+	if clobbers != expected {
+		t.Fatal("Expected clobbers not to include indirect registers that are also specified")
+	}
+}

--- a/env.go
+++ b/env.go
@@ -257,6 +257,7 @@ func (e *Environment) ParseNextWord() bool {
 
 	var instrs []Instr
 	var clobbers uint
+	var indirectRegisters uint
 	shouldOptimize := false
 
 	if word := e.Dictionary.Find(name); word != nil {
@@ -274,6 +275,7 @@ func (e *Environment) ParseNextWord() bool {
 		}
 
 		clobbers = word.Clobbers
+		indirectRegisters = word.Registers
 		instrs = instrsForWord(word)
 	} else if _, found := x8664Lowerers[name]; found {
 		instrs = []Instr{&X8664Instr{Mnemonic: name}}
@@ -297,8 +299,9 @@ func (e *Environment) ParseNextWord() bool {
 	}
 
 	if e.Compiling {
-		clobbers &= ^e.Dictionary.Latest.Registers
-		e.Dictionary.Latest.Clobbers |= clobbers
+		e.Dictionary.Latest.Clobbers |= UpdatedClobbers(clobbers,
+			e.Dictionary.Latest.Registers,
+			indirectRegisters)
 	}
 
 	return true

--- a/instr.go
+++ b/instr.go
@@ -446,8 +446,6 @@ func flowWordOutputs(word *Word, env *Environment, context *RunContext) {
 		env.AppendAsmInstrs(flowInstrs)
 	}
 
-	// buildClobberGuards(word, context)
-
 	wordOutputs := word.OutputRegisters()
 	context.Inputs = append(context.Inputs, wordOutputs...)
 }

--- a/tools/bake/bake.asm
+++ b/tools/bake/bake.asm
@@ -207,9 +207,7 @@ __blue_1939608060_0:
 	dec rsi
 	ret
 
-;  TODO this is an example of needing indirect clobber detection
-
-; : cstr>str ( cstr:rdx -- str:rsi len:rdx | rdi )
+; : cstr>str ( cstr:rdx -- str:rsi len:rdx )
 
 __blue_3207375596_0:
 	mov rdi, rdx

--- a/tools/bake/bake.asm
+++ b/tools/bake/bake.asm
@@ -5,7 +5,7 @@
 
 ;  system call numbers
 
-; : syscall ( num:eax -- result:eax )
+; : syscall ( num:eax -- result:eax | rcx )
 
 __blue_4057121178_0:
 	syscall

--- a/tools/bake/linux/x8664/syscalls.blue
+++ b/tools/bake/linux/x8664/syscalls.blue
@@ -1,4 +1,4 @@
-: syscall ( num:eax -- result:eax ) syscall ;
+: syscall ( num:eax -- result:eax | rcx ) syscall ;
 
 : exit ( status:edi -- noret ) exit syscall ;
 

--- a/tools/bake/x8664/strings.blue
+++ b/tools/bake/x8664/strings.blue
@@ -1,8 +1,7 @@
 : find0 ( start:rsi -- end:rsi ) lodsb 0 cmp latest xne ; 
 : cstrlen ( str:rdi -- len:rsi ) dup find0 swap sub dec ;
 
-\ TODO this is an example of needing indirect clobber detection
-: cstr>str ( cstr:rdx -- str:rsi len:rdx | rdi ) dup cstrlen xchg ;
+: cstr>str ( cstr:rdx -- str:rsi len:rdx ) dup cstrlen xchg ;
 
 \ TODO swap drop -> nip
 : copy-str ( src:rsi len:rcx dest:rdi -- tail:rdi ) rot swap movsb swap drop swap rep ;

--- a/x8664.go
+++ b/x8664.go
@@ -235,14 +235,14 @@ var registerNamesBySize = map[string][]string{
 	size64: reg64Names,
 	size32: reg32Names,
 	size16: reg16Names,
-	size8: reg8Names,
+	size8:  reg8Names,
 }
 
 var registerSizeInBytes = map[string]uint{
 	size64: 8,
 	size32: 4,
 	size16: 2,
-	size8: 1,
+	size8:  1,
 }
 
 var registerSize = map[string]string{


### PR DESCRIPTION
Mark indirect registers (those used by a called word but not specified in the current words stack references) as clobbered. Prevents needing to manually track which registers each called word use.