### PR TITLE
Flow inlined words

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,17 +3,13 @@
 1. more unit tests
    1. needs to be easier to test Instr and AsmInstr
 1. CondCall is not flowing yet
-1. inline is not flowing yet
 1. import vs use - one brings in externs other all code from file
    1. link vs include? - use to determine how to build via dsl?
 1. better newline support when generating asm
 1. when importing, can drop the global decls from the imported env?
 1. continue to infer registers from word body
-   1. if fully specified, check if inferable
-   1. infer during word fallthrough? whole program infer?
-   1. needs x8664 "words" to have register definitions
-1. validate needs to check for lingering refs/stack items
-   1. some fatal logs exist
+   1. infer during word fallthrough?
+   1. need x8664 "words" to have register definitions
 1. treat words with only decb more like resb
    1. global strings also fall into this bucket
 1. More peephole optimizations

--- a/env.go
+++ b/env.go
@@ -254,10 +254,6 @@ func instrsForWord(word *Word) []Instr {
 			lastIdx -= 1
 		}
 
-		// TODO debug the inference issue when the inlined word
-		// is flowed
-		// ---
-		// one issue is the swap in echo.blue's second write
 		instrs = append(instrs, word.Code[:lastIdx]...)
 		//instrs = word.Code[:lastIdx]
 	}

--- a/env.go
+++ b/env.go
@@ -252,7 +252,7 @@ func instrsForWord(word *Word) []Instr {
 	if !word.IsInline() {
 		instrs = append(instrs, &CallWordInstr{Word: word})
 	} else {
-
+		// TODO inline handling should be moved when whole word optimizations land
 		lastIdx := len(word.Code)
 		if _, isRet := word.Code[lastIdx-1].(*RetInstr); isRet {
 			lastIdx -= 1

--- a/env.go
+++ b/env.go
@@ -263,7 +263,13 @@ func (e *Environment) ParseNextWord() bool {
 	if word := e.Dictionary.Find(name); word != nil {
 		// TODO this IsInline check isn't quite right
 		// eg: rot doesn't run when not compiling
-		// need to recall reason this was added and fix properly
+		// ---
+		// inline is here working around the fact that we start a new
+		// run context to execute words. A word like rot expects 3
+		// inputs at runtime, but in the case of not compiling the
+		// previous inputs are LiteralIntInstr on the code buf.
+		// since these types of words do not currently declare their
+		// inputs/outputs we can't convert codebuf->stackrefs
 		if (!e.Compiling || word.IsImmediate()) && !word.IsInline() {
 			context := &RunContext{}
 
@@ -295,6 +301,10 @@ func (e *Environment) ParseNextWord() bool {
 		// and cover more cases than just asm instructions (move leading string
 		// before word, etc). Need to consider how this interacts with computing
 		// the flow between words
+		// ---
+		// this is also working around the same issue described above. We can't
+		// properly interpret things like 1 2 or, so instead rely on the
+		// optimizer after each instruction which isn't good
 		e.OptimizeInstrs()
 	}
 

--- a/env.go
+++ b/env.go
@@ -243,7 +243,11 @@ func (e *Environment) ReadTil(s string) string {
 }
 
 func instrsForWord(word *Word) []Instr {
-	instrs := []Instr{&FlowWordInstr{Word: word}}
+	var instrs []Instr
+
+	if word.HasStackRefs() {
+		instrs = append(instrs, &FlowWordInstr{Word: word})
+	}
 
 	if !word.IsInline() {
 		instrs = append(instrs, &CallWordInstr{Word: word})
@@ -255,7 +259,6 @@ func instrsForWord(word *Word) []Instr {
 		}
 
 		instrs = append(instrs, word.Code[:lastIdx]...)
-		//instrs = word.Code[:lastIdx]
 	}
 
 	return instrs

--- a/env.go
+++ b/env.go
@@ -234,19 +234,26 @@ func (e *Environment) ReadTil(s string) string {
 }
 
 func instrsForWord(word *Word) []Instr {
+	instrs := []Instr{&FlowWordInstr{Word: word}}
+
 	if !word.IsInline() {
-		return []Instr{
-			&FlowWordInstr{Word: word},
-			&CallWordInstr{Word: word},
+		instrs = append(instrs, &CallWordInstr{Word: word})
+	} else {
+
+		lastIdx := len(word.Code)
+		if _, isRet := word.Code[lastIdx-1].(*RetInstr); isRet {
+			lastIdx -= 1
 		}
+
+		// TODO debug the inference issue when the inlined word
+		// is flowed
+		// ---
+		// one issue is the swap in echo.blue's second write
+		instrs = append(instrs, word.Code[:lastIdx]...)
+		//instrs = word.Code[:lastIdx]
 	}
 
-	lastIdx := len(word.Code)
-	if _, isRet := word.Code[lastIdx-1].(*RetInstr); isRet {
-		lastIdx -= 1
-	}
-
-	return word.Code[:lastIdx]
+	return instrs
 }
 
 func (e *Environment) ParseNextWord() bool {

--- a/language/examples/rosettacode/create_file.asm
+++ b/language/examples/rosettacode/create_file.asm
@@ -69,8 +69,10 @@ __blue_2883839448_0:
 ; : create-file ( pathname -- )
 
 __blue_3101971046_0:
+	or 64, 1
+	or 64, 512
 	mov edx, 416
-	mov esi, 577
+	mov esi, 64
 	call __blue_3546203337_0
 	mov edi, eax
 	call __blue_667630371_0

--- a/language/examples/rosettacode/create_file.asm
+++ b/language/examples/rosettacode/create_file.asm
@@ -69,10 +69,8 @@ __blue_2883839448_0:
 ; : create-file ( pathname -- )
 
 __blue_3101971046_0:
-	or 64, 1
-	or 64, 512
 	mov edx, 416
-	mov esi, 64
+	mov esi, 577
 	call __blue_3546203337_0
 	mov edi, eax
 	call __blue_667630371_0

--- a/word.go
+++ b/word.go
@@ -55,6 +55,10 @@ func (w *Word) AppendOutput(r *StackRef) {
 	w.Outputs = append(w.Outputs, r)
 }
 
+func (w *Word) HasStackRefs() bool {
+	return len(w.Inputs) > 0 || len(w.Outputs) > 0
+}
+
 func (w *Word) HasCompleteRefs() bool {
 	return RefsAreComplete(w.Inputs) && RefsAreComplete(w.Outputs)
 }


### PR DESCRIPTION
Previously they were not considered when flowing registers, so the developer had to implicitly line everything up at design time.