### PR TITLE
Calculate values for variable portions of the elf headers

### DIFF
--- a/blue.asm
+++ b/blue.asm
@@ -121,7 +121,7 @@ segment readable executable
 entry $
 	mov	rdi, output_file
 	mov	esi, 0x01 or 0x40 or 0x200
-	mov	edx, 0x1a0
+	mov	edx, 0x1ed
 	mov	eax, 2
 	syscall
 
@@ -132,11 +132,6 @@ entry $
 	mov	rsi, output
 	mov	rdx, output.length
 	mov	eax, 1
-	syscall
-
-	pop	rdi
-	mov	esi, 0x1ed
-	mov	eax, 91
 	syscall
 
 	pop	rdi

--- a/blue.asm
+++ b/blue.asm
@@ -138,6 +138,7 @@ entry $
 	;
 	mov	eax, elf_header.length + program_header.length
 	mov	qword [program_code_section_header.offset], rax
+	mov	qword [program_code_section_header.size], program_code.length
 	
 	add	eax, program_code.length
 	mov 	rdi, program_header.sizes
@@ -149,8 +150,6 @@ entry $
 
 	mov	eax, shstrtab.length
 	stosq
-
-	mov	qword [program_code_section_header.size], program_code.length
 
 	;
 	; write the output to ./a.out

--- a/blue.asm
+++ b/blue.asm
@@ -89,7 +89,7 @@ program_code_section_header:
 	dq 	0x06			; flags - executable | in memory
 	dq 	0x400078		; addr in virtual memory of section
 	.offset:
-	dq 	0x78			; offset in the file of this section
+	dq 	0x00			; offset in the file of this section
 	.size:
 	dq 	0x00			; size of this section in the file
 	dq 	0x00			; sh_link - not used


### PR DESCRIPTION
On the first pass of porting the example, hardcoded values for various sizes and offsets were used. Most of those values are calculated now. Still using the hardcoded start address.