### PR TITLE
Better clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 blue
 *.out
-
-code_buffer_test
-elf_test
-elf_test_hello_world

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,15 @@ run:
 dis:
 	$(DISASM) a.out
 
+clean:
+	rm -f $(BLUE) a.out
+
 watch:
 	watch -d make compile run
-
+	
 .PHONY:
 	dev-env dev-start dev-stop \
-	compile run dis \
-	watch watch-tests
+	compile run dis clean \
+	watch
 
 include test.mk

--- a/test.mk
+++ b/test.mk
@@ -5,10 +5,13 @@ TESTS := \
 	elf_test_hello_world
 
 $(TESTS):
-	echo "Testing $@... " && make WHAT=$@ compile run && echo ""
+	echo "Testing $@... " && \
+	make WHAT=$@ compile run && \
+	rm -f $@ && \
+	echo ""
 
 tests: $(TESTS)
-	@/bin/true
+	rm -f elf_test_hello_world.out
 
 tests-watch:
 	watch -d make tests


### PR DESCRIPTION
Remove test binaries after the test runs successfully, add clean target to remove the compiler binary and its output.