### PR TITLE
Interpretive dance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 blue
 *.out
+
+kernel_test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 blue
 *.out
-
-kernel_test

--- a/code_buffer.inc
+++ b/code_buffer.inc
@@ -5,6 +5,12 @@ _core_code:
 	stosb
 	mov	[_code_buffer.here], rdi
 	ret
+
+	.b_comma2:
+	mov edi, eax
+	mov eax, 60
+	syscall
+	ret
 	
 	.d_comma:
 	mov	rdi, [_code_buffer.here]

--- a/code_buffer.inc
+++ b/code_buffer.inc
@@ -6,24 +6,12 @@ _core_code:
 	mov	[_code_buffer.here], rdi
 	ret
 
-	.b_comma2:
-	mov edi, eax
-	mov eax, 60
-	syscall
-	ret
-	
 	.d_comma:
 	mov	rdi, [_code_buffer.here]
 	stosd
 	mov	[_code_buffer.here], rdi
 	ret
-	
-	.q_comma:
-	mov	rdi, [_code_buffer.here]
-	stosq
-	mov	[_code_buffer.here], rdi
-	ret
-	
+		
 code_buffer_init:
 	mov	esi, _code_buffer.length
 	mov	edx, PROT_RWX

--- a/code_buffer.inc
+++ b/code_buffer.inc
@@ -22,6 +22,7 @@ code_buffer_init:
 	stosq
 
 	xor	eax, eax
+	stosq
 	stosd
 	
 	ret

--- a/code_buffer.inc
+++ b/code_buffer.inc
@@ -12,6 +12,12 @@ _core_code:
 	mov	[_code_buffer.here], rdi
 	ret
 	
+	.q_comma:
+	mov	rdi, [_code_buffer.here]
+	stosq
+	mov	[_code_buffer.here], rdi
+	ret
+	
 code_buffer_init:
 	mov	esi, _code_buffer.length
 	mov	edx, PROT_RWX

--- a/code_buffer_test.asm
+++ b/code_buffer_test.asm
@@ -17,6 +17,12 @@ entry $
 	cmp	rax, [_code_buffer.here]
 	jne	exit
 
+	cmp	[_code_buffer.mark], 0
+	jne	exit
+
+	cmp	[_code_buffer.entry], 0
+	jne	exit
+
 	mov	al, 123
 	call	_core_code.b_comma
 	

--- a/defs.inc
+++ b/defs.inc
@@ -18,6 +18,7 @@ _blue:
 	
 _code_buffer:
 	.length = 4096
+	.interpret_offset = 1024
 	.base dq 1
 	.here dq 1
 	.mark dq 1

--- a/defs.inc
+++ b/defs.inc
@@ -20,6 +20,7 @@ _code_buffer:
 	.length = 4096
 	.base dq 1
 	.here dq 1
+	.mark dq 1
 	.entry dd 1
 
 _data_stack:

--- a/kernel.inc
+++ b/kernel.inc
@@ -71,9 +71,9 @@ _interpretive_dance:
 	call	_core_code.b_comma
 
 	mov	rsi, [_code_buffer.mark]
+	mov	rdi, rsi
 	add	rsi, _code_buffer.interpret_offset
 
-	mov	rdi, [_code_buffer.mark]
 	mov	[_code_buffer.here], rdi
 
 	xor	rdi, rdi

--- a/kernel.inc
+++ b/kernel.inc
@@ -118,7 +118,7 @@ _handle_word:
 	push	rax
 	call	_flow_in
 
-	mov	al, 0x48_
+	mov	al, 0x48
 	call	_core_code.b_comma
 	mov	al, 0xc7
 	call	_core_code.b_comma

--- a/kernel.inc
+++ b/kernel.inc
@@ -65,9 +65,9 @@ _interpret:
 	ret
 
 _interpretive_dance:
-	mov	eax, 0xc3
+	mov	al, 0xc3
 	call	_core_code.b_comma
-	call	[_code_buffer.mark]
+	;call	[_code_buffer.mark]
 	
 	ret
 
@@ -115,20 +115,20 @@ _handle_word:
 	call	_core_code.b_comma
 
 	pop	rax
-	add	rax, _dictionary.code_offset
-	mov	rax, [rsi]
-	call	_core_code.d_comma
 
-	;sub	rax, [_code_buffer.here]
-	;sub	rax, 4
-	;call	_core_code.d_comma
+	add	rax, _dictionary.code_offset
+	mov	rax, [rax]
+	sub	rax, [_code_buffer.here]
+	sub	rax, 4
+
+	call	_core_code.d_comma
 
 	pop	rax
 	call	_flow_out
 	
 	ret
 
-_________bak:
+_XX_bak:
 
 	push	rax
 	call	data_stack_pop

--- a/kernel.inc
+++ b/kernel.inc
@@ -82,10 +82,6 @@ _interpretive_dance:
 	
 	call	rsi
 	
-	mov	edi, 21
-	mov	eax, 60
-	syscall
-	
 	ret
 
 _compile:
@@ -119,10 +115,25 @@ _flow_out:
 ;	- word in rax
 ;
 _handle_word:
-	call _flow_in
+	call	_flow_in
 
-	xor eax, eax
+	mov	al, 0x48
+	call	_core_code.b_comma
+	mov	al, 0xc7
+	call	_core_code.b_comma
+	mov	al, 0xc0
+	call	_core_code.b_comma
+	
+	mov	rax, _core_code.b_comma	
+	call	_core_code.d_comma
 
+	mov	al, 0xff
+	call	_core_code.b_comma
+	mov	al, 0xd0
+	call	_core_code.b_comma
+
+	ret
+	
 	mov	al, 49
 	call	_core_code.b_comma
 	mov	al, 255
@@ -138,10 +149,14 @@ _handle_word:
 	mov	al, 5
 	call	_core_code.b_comma
 	
+	;mov	rax, [_code_buffer.mark]
+	;add	rax, _code_buffer.interpret_offset
+	;call	rax
+
 	ret
 
 	.ok:
-	mov	edi, 21
+	mov	edi, 31
 	mov	eax, 60
 	syscall
 	

--- a/kernel.inc
+++ b/kernel.inc
@@ -5,7 +5,8 @@ kernel_init:
 	call	dictionary_init
 
 	mov	[_blue.base], 10
-	mov	[_blue.mode], INTERPRET
+
+	call	_interpret
 	
 	ret
 
@@ -42,6 +43,7 @@ kernel_loop:
 	jmp	.loop
 
 	.done:
+	call	_interpretive_dance
 	mov	eax, SUCCESS
 	ret
 
@@ -54,19 +56,42 @@ kernel_deinit:
 	call	data_stack_deinit
 	call	code_buffer_deinit
 	ret
+;
+; expects
+;	- word in rax
+;
+_interpret:
+	mov	rdi, [_code_buffer.here]
+	mov	[_code_buffer.mark], rdi
+	
+	mov	[_blue.mode], INTERPRET
+	ret
+
+_interpretive_dance:
+	mov	eax, 0xc3
+	call	_core_code.b_comma
+	call	[_code_buffer.mark]
+	
+	ret
+;
+; expects
+;	- word in rax
+;
+_compile:
+	call	_interpretive_dance
+	mov	rdi, [_code_buffer.mark]
+	mov	[_code_buffer.here], rdi
+	xor	rdi, rdi
+	mov	[_code_buffer.mark], rdi
+	
+	mov	[_blue.mode], COMPILE
+	ret
 
 ;
 ; expects
 ;	- word in rax
 ;
 _handle_word:
-	test	al, DE_IMMEDIATE
-	jnz	.interpret
-
-	test	[_blue.mode], INTERPRET
-	jnz	.interpret
-
-	.interpret:
 	push	rax	
 	call	data_stack_pop
 	pop	rsi
@@ -76,5 +101,16 @@ _handle_word:
 	call	rsi
 	ret
 
-	.compile:
+____bak:
+	test	al, DE_IMMEDIATE
+	jnz	.interpret
+
+	test	[_blue.mode], INTERPRET
+	jnz	.interpret
+
+	call	_compile
+	ret
+
+	.interpret:
+	call	_interpret
 	ret

--- a/kernel.inc
+++ b/kernel.inc
@@ -43,7 +43,7 @@ kernel_loop:
 	jmp	.loop
 
 	.done:
-	call	_interpretive_dance
+	call	_compile ;_interpretive_dance
 	mov	eax, SUCCESS
 	ret
 
@@ -56,10 +56,7 @@ kernel_deinit:
 	call	data_stack_deinit
 	call	code_buffer_deinit
 	ret
-;
-; expects
-;	- word in rax
-;
+
 _interpret:
 	mov	rdi, [_code_buffer.here]
 	mov	[_code_buffer.mark], rdi
@@ -73,10 +70,7 @@ _interpretive_dance:
 	call	[_code_buffer.mark]
 	
 	ret
-;
-; expects
-;	- word in rax
-;
+
 _compile:
 	call	_interpretive_dance
 	mov	rdi, [_code_buffer.mark]
@@ -91,14 +85,60 @@ _compile:
 ; expects
 ;	- word in rax
 ;
+_flow_in:
+	mov	al, 0xb8
+	call	_core_code.b_comma
+
+	call	data_stack_pop
+	call	_core_code.d_comma
+
+	ret
+
+;
+; expects
+;	- word in rax
+;
+_flow_out:
+	ret
+
+;
+; expects
+;	- word in rax
+;
 _handle_word:
-	push	rax	
+	push	rax
+	push	rax
+
+	call	_flow_in
+
+	mov	al, 0xe8
+	call	_core_code.b_comma
+
+	pop	rax
+	add	rax, _dictionary.code_offset
+	mov	rax, [rsi]
+	call	_core_code.d_comma
+
+	;sub	rax, [_code_buffer.here]
+	;sub	rax, 4
+	;call	_core_code.d_comma
+
+	pop	rax
+	call	_flow_out
+	
+	ret
+
+_________bak:
+
+	push	rax
 	call	data_stack_pop
 	pop	rsi
 
 	add	rsi, _dictionary.code_offset
 	mov	rsi, [rsi]
 	call	rsi
+	
+	call	_flow_out
 	ret
 
 ____bak:

--- a/kernel.inc
+++ b/kernel.inc
@@ -114,6 +114,8 @@ _flow_out:
 ;	- word in rax
 ;
 _handle_word:
+	push	rax
+	push	rax
 	call	_flow_in
 
 	mov	al, 0x48			; mov rdi, _word's code_
@@ -122,8 +124,10 @@ _handle_word:
 	call	_core_code.b_comma
 	mov	al, 0xc7
 	call	_core_code.b_comma
-	
-	mov	rax, _core_code.b_comma
+
+	pop	rax
+	add	rax, _dictionary.code_offset
+	mov	rax, [rax]
 	call	_core_code.d_comma
 
 	mov	al, 0xff			; call rdi
@@ -131,4 +135,7 @@ _handle_word:
 	mov	al, 0xd7
 	call	_core_code.b_comma
 
+	pop	rax
+	call	_flow_out
+	
 	ret

--- a/kernel.inc
+++ b/kernel.inc
@@ -60,6 +60,9 @@ kernel_deinit:
 _interpret:
 	mov	rdi, [_code_buffer.here]
 	mov	[_code_buffer.mark], rdi
+
+	add	rdi, _code_buffer.interpret_offset
+	mov	[_code_buffer.here], rdi
 	
 	mov	[_blue.mode], INTERPRET
 	ret
@@ -67,17 +70,27 @@ _interpret:
 _interpretive_dance:
 	mov	al, 0xc3
 	call	_core_code.b_comma
-	;call	[_code_buffer.mark]
+
+	mov	rsi, [_code_buffer.mark]
+	add	rsi, _code_buffer.interpret_offset
+
+	mov	rdi, [_code_buffer.mark]
+	mov	[_code_buffer.here], rdi
+
+	xor	rdi, rdi
+	mov	[_code_buffer.mark], rdi
+	
+	call	rsi
+	
+	mov	edi, 21
+	mov	eax, 60
+	syscall
 	
 	ret
 
 _compile:
 	call	_interpretive_dance
-	mov	rdi, [_code_buffer.mark]
-	mov	[_code_buffer.here], rdi
-	xor	rdi, rdi
-	mov	[_code_buffer.mark], rdi
-	
+
 	mov	[_blue.mode], COMPILE
 	ret
 
@@ -106,6 +119,33 @@ _flow_out:
 ;	- word in rax
 ;
 _handle_word:
+	call _flow_in
+
+	xor eax, eax
+
+	mov	al, 49
+	call	_core_code.b_comma
+	mov	al, 255
+	call	_core_code.b_comma
+
+	mov	al, 184
+	call	_core_code.b_comma
+	mov	al, 60
+	call	_core_code.d_comma
+	
+	mov	al, 15
+	call	_core_code.b_comma
+	mov	al, 5
+	call	_core_code.b_comma
+	
+	ret
+
+	.ok:
+	mov	edi, 21
+	mov	eax, 60
+	syscall
+	
+_bak:
 	push	rax
 	push	rax
 
@@ -115,11 +155,14 @@ _handle_word:
 	call	_core_code.b_comma
 
 	pop	rax
-
-	add	rax, _dictionary.code_offset
-	mov	rax, [rax]
+	mov	rax, _core_code.b_comma
 	sub	rax, [_code_buffer.here]
 	sub	rax, 4
+
+	;add	rax, _dictionary.code_offset
+	;mov	rax, [rax]
+	;sub	rax, [_code_buffer.here]
+	;sub	rax, 4
 
 	call	_core_code.d_comma
 

--- a/kernel.inc
+++ b/kernel.inc
@@ -5,8 +5,6 @@ kernel_init:
 	call	dictionary_init
 
 	mov	[_blue.base], 10
-
-	call	_interpret
 	
 	ret
 
@@ -20,6 +18,8 @@ kernel_loop:
 	mov	[_blue.tib], rsi
 	mov	[_blue.tib_len], ecx
 	mov	[_blue.tib_in], eax
+
+	call	_interpret
 
 	.loop:
 	call	parser_next_word
@@ -43,7 +43,7 @@ kernel_loop:
 	jmp	.loop
 
 	.done:
-	call	_compile ;_interpretive_dance
+	call	_compile
 	mov	eax, SUCCESS
 	ret
 

--- a/kernel.inc
+++ b/kernel.inc
@@ -5,6 +5,7 @@ kernel_init:
 	call	dictionary_init
 
 	mov	[_blue.base], 10
+	call	_interpret
 	
 	ret
 
@@ -18,8 +19,6 @@ kernel_loop:
 	mov	[_blue.tib], rsi
 	mov	[_blue.tib_len], ecx
 	mov	[_blue.tib_in], eax
-
-	call	_interpret
 
 	.loop:
 	call	parser_next_word
@@ -43,7 +42,7 @@ kernel_loop:
 	jmp	.loop
 
 	.done:
-	call	_compile
+	call	_interpretive_dance
 	mov	eax, SUCCESS
 	ret
 
@@ -79,7 +78,7 @@ _interpretive_dance:
 
 	xor	rdi, rdi
 	mov	[_code_buffer.mark], rdi
-	
+
 	call	rsi
 	
 	ret
@@ -117,98 +116,19 @@ _flow_out:
 _handle_word:
 	call	_flow_in
 
-	mov	al, 0x48
+	mov	al, 0x48			; mov rdi, _word's code_
 	call	_core_code.b_comma
 	mov	al, 0xc7
 	call	_core_code.b_comma
-	mov	al, 0xc0
+	mov	al, 0xc7
 	call	_core_code.b_comma
 	
-	mov	rax, _core_code.b_comma	
-	call	_core_code.d_comma
-
-	mov	al, 0xff
-	call	_core_code.b_comma
-	mov	al, 0xd0
-	call	_core_code.b_comma
-
-	ret
-	
-	mov	al, 49
-	call	_core_code.b_comma
-	mov	al, 255
-	call	_core_code.b_comma
-
-	mov	al, 184
-	call	_core_code.b_comma
-	mov	al, 60
-	call	_core_code.d_comma
-	
-	mov	al, 15
-	call	_core_code.b_comma
-	mov	al, 5
-	call	_core_code.b_comma
-	
-	;mov	rax, [_code_buffer.mark]
-	;add	rax, _code_buffer.interpret_offset
-	;call	rax
-
-	ret
-
-	.ok:
-	mov	edi, 31
-	mov	eax, 60
-	syscall
-	
-_bak:
-	push	rax
-	push	rax
-
-	call	_flow_in
-
-	mov	al, 0xe8
-	call	_core_code.b_comma
-
-	pop	rax
 	mov	rax, _core_code.b_comma
-	sub	rax, [_code_buffer.here]
-	sub	rax, 4
-
-	;add	rax, _dictionary.code_offset
-	;mov	rax, [rax]
-	;sub	rax, [_code_buffer.here]
-	;sub	rax, 4
-
 	call	_core_code.d_comma
 
-	pop	rax
-	call	_flow_out
-	
-	ret
+	mov	al, 0xff			; call rdi
+	call	_core_code.b_comma
+	mov	al, 0xd7
+	call	_core_code.b_comma
 
-_XX_bak:
-
-	push	rax
-	call	data_stack_pop
-	pop	rsi
-
-	add	rsi, _dictionary.code_offset
-	mov	rsi, [rsi]
-	call	rsi
-	
-	call	_flow_out
-	ret
-
-____bak:
-	test	al, DE_IMMEDIATE
-	jnz	.interpret
-
-	test	[_blue.mode], INTERPRET
-	jnz	.interpret
-
-	call	_compile
-	ret
-
-	.interpret:
-	call	_interpret
 	ret

--- a/kernel.inc
+++ b/kernel.inc
@@ -118,7 +118,7 @@ _handle_word:
 	push	rax
 	call	_flow_in
 
-	mov	al, 0x48			; mov rdi, _word's code_
+	mov	al, 0x48_
 	call	_core_code.b_comma
 	mov	al, 0xc7
 	call	_core_code.b_comma
@@ -130,7 +130,7 @@ _handle_word:
 	mov	rax, [rax]
 	call	_core_code.d_comma
 
-	mov	al, 0xff			; call rdi
+	mov	al, 0xff
 	call	_core_code.b_comma
 	mov	al, 0xd7
 	call	_core_code.b_comma

--- a/kernel_test.asm
+++ b/kernel_test.asm
@@ -66,10 +66,13 @@ entry $
 	
 	call	kernel_deinit
 
-	tc1	clean_exit.blue, clean_exit.blue_length, \
-		clean_exit.expected, clean_exit.expected_length 
+	tc1	one.blue, one.blue_length, \
+		one.expected, one.expected_length 
 
-	tc2	bogus.blue, bogus.blue_length
+	;tc1	clean_exit.blue, clean_exit.blue_length, \
+	;	clean_exit.expected, clean_exit.expected_length 
+
+	;tc2	bogus.blue, bogus.blue_length
 		
 	xor	edi, edi
 	
@@ -84,8 +87,6 @@ failure:
 check_code_buffer:
 	mov	rdi, [_code_buffer.here]
 	sub	rdi, [_code_buffer.base]
-	mov eax, 60
-	syscall
 
 	cmp	edi, ecx
 	jne	failure
@@ -108,6 +109,15 @@ bogus:
 	db	'^%^*^%'
 	.blue_length = $ - .blue
 
+one:
+	.blue:
+	db	'1 b,'
+	.blue_length = $ - .blue
+
+	.expected:
+	db	0x01
+	.expected_length = $ - .expected
+	
 clean_exit:
 	.blue:
 	db	'49 b, 255 b, '		; xor edi, edi

--- a/kernel_test.asm
+++ b/kernel_test.asm
@@ -88,6 +88,9 @@ failure:
 check_code_buffer:
 	mov	rdi, [_code_buffer.here]
 	sub	rdi, [_code_buffer.base]
+	mov eax, 60
+	syscall
+
 	cmp	edi, ecx
 	jne	failure
 

--- a/kernel_test.asm
+++ b/kernel_test.asm
@@ -64,10 +64,6 @@ entry $
 	cmp	[_blue.base], 10
 	jne	failure
 	
-	inc	[test_num]
-	cmp	[_blue.mode], INTERPRET
-	jne	failure
-	
 	call	kernel_deinit
 
 	tc1	clean_exit.blue, clean_exit.blue_length, \

--- a/kernel_test.asm
+++ b/kernel_test.asm
@@ -63,16 +63,20 @@ entry $
 	inc	[test_num]
 	cmp	[_blue.base], 10
 	jne	failure
+
+	inc	[test_num]
+	cmp	[_blue.mode], INTERPRET
+	jne	failure
 	
 	call	kernel_deinit
 
 	tc1	one.blue, one.blue_length, \
 		one.expected, one.expected_length 
 
-	;tc1	clean_exit.blue, clean_exit.blue_length, \
-	;	clean_exit.expected, clean_exit.expected_length 
+	tc1	clean_exit.blue, clean_exit.blue_length, \
+		clean_exit.expected, clean_exit.expected_length 
 
-	;tc2	bogus.blue, bogus.blue_length
+	tc2	bogus.blue, bogus.blue_length
 		
 	xor	edi, edi
 	

--- a/kernel_test.asm
+++ b/kernel_test.asm
@@ -90,9 +90,9 @@ check_code_buffer:
 
 	cmp	edi, ecx
 	jne	failure
-
+	
 	mov	rdi, [_code_buffer.base]
-
+	
 	.loop:
 	cmpsb
 	jne	failure


### PR DESCRIPTION
Ports the interpretive dance logic from the original nasm based demo. This allows previously compiled code to be executed at compile time without any emulation layer.