### PR TITLE
Add base 16 parser

### DIFF
--- a/to_number.inc
+++ b/to_number.inc
@@ -9,7 +9,28 @@ to_number:
 	mov	cl, [_blue.word_len]
 	mov	rsi, _blue.word
 
-	.loop:
+	xor	ebx, ebx
+	mov	bl, [_blue.base]
+
+	cmp	bl, 10
+	je	.base10_loop
+
+	cmp	bl, 16
+	je	.base16_loop
+
+	.failure:
+	mov	eax, FAILURE
+	ret
+
+	.success:
+	mov	eax, SUCCESS
+	ret
+
+	;
+	; decimal
+	;
+	
+	.base10_loop:
 	lodsb
 
 	cmp	al, 57
@@ -19,15 +40,42 @@ to_number:
 	js	.failure
 
 	xchg	eax, edi
-	mul	[_blue.base]
+	mul	ebx
 	xadd	edi, eax
 
 	dec	cl
-	jnz	.loop
+	jnz	.base10_loop
+	jmp	.success
 
-	mov	eax, SUCCESS
-	ret
+	;
+	; hex
+	;
+	
+	.base16_loop:
+	lodsb
 
-	.failure:
-	mov	eax, FAILURE
-	ret
+	cmp	al, 57
+	jg	.base16_AF
+
+	sub	al, 48
+	js	.failure
+
+	.base16_mul:
+	xchg	eax, edi
+	mul	ebx
+	xadd	edi, eax
+
+	dec	cl
+	jnz	.base16_loop
+	jmp	.success
+
+	.base16_AF:
+	cmp	al, 70
+	jg	.failure
+
+	sub	al, 55
+	cmp	al, 10
+	jl	.failure
+
+	jmp	.base16_mul
+

--- a/to_number_test.inc
+++ b/to_number_test.inc
@@ -34,6 +34,16 @@ to_number_test:
 	tc1	thirteen, 2, SUCCESS, 13
 	tc1	thousand, 4, SUCCESS, 1000
 
+	mov	[_blue.base], 16
+	tc1	not_number, 4, FAILURE, 0
+	tc1	not_number2, 5, FAILURE, 4660
+	tc1	zero, 1, SUCCESS, 0
+	tc1	one, 1, SUCCESS, 1
+	tc1	thirteen, 2, SUCCESS, 19
+	tc1	thousand, 4, SUCCESS, 4096
+	tc1	FF, 2, SUCCESS, 255
+	tc1	ABCDEF, 6, SUCCESS, 11259375
+
 	ret
 
 not_number	db '!@#$'
@@ -42,3 +52,5 @@ zero		db '0'
 one		db '1'
 thirteen	db '13'
 thousand	db '1000'
+FF		db 'FF'
+ABCDEF		db 'ABCDEF'

--- a/to_number_test.inc
+++ b/to_number_test.inc
@@ -35,6 +35,7 @@ to_number_test:
 	tc1	thousand, 4, SUCCESS, 1000
 
 	mov	[_blue.base], 16
+	
 	tc1	not_number, 4, FAILURE, 0
 	tc1	not_number2, 5, FAILURE, 4660
 	tc1	zero, 1, SUCCESS, 0


### PR DESCRIPTION
Adds a base 16 parser to `to_number`. Needs a corresponding `base` word exposed which requires some pending work to the kernel loop.