### PR TITLE
Move core code out of code_buffer.inc

### DIFF
--- a/code_buffer.inc
+++ b/code_buffer.inc
@@ -1,20 +1,3 @@
-
-_core_code:
-	.b_comma:
-	mov	rdi, [_code_buffer.here]
-	stosb
-	mov	[_code_buffer.here], rdi
-	ret
-
-	.d_comma:
-	mov	rdi, [_code_buffer.here]
-	stosd
-	mov	[_code_buffer.here], rdi
-	ret
-
-	.base:
-	mov	[_blue.base], al
-	ret
 		
 code_buffer_init:
 	mov	esi, _code_buffer.length

--- a/code_buffer_test.inc
+++ b/code_buffer_test.inc
@@ -24,53 +24,6 @@ code_buffer_test:
 
 	ok
 
-	t 'b, writes a byte'
-
-	mov	al, 123
-	call	_core_code.b_comma
-	
-	mov	rax, [_code_buffer.base]
-	mov	rcx, [_code_buffer.here]
-	sub	rcx, rax
-	cmp	ecx, 1
-	jne	failure
-	push	rax
-
-	ok
-
-	t 'b, writes the correct value'
-
-	pop	rax
-	mov	rax, [rax]
-	cmp	al, 123
-	jne	failure
-
-	ok
-
-	t 'd, writes a dword'
-	
-	mov	eax, 123456
-	call	_core_code.d_comma
-
-	mov	rax, [_code_buffer.base]
-	inc	rax
-	mov	rcx, [_code_buffer.here]
-	sub	rcx, rax
-	cmp	ecx, 4
-	jne	failure
-	push	rax
-
-	ok
-
-	t 'd, writes the correct value'
-
-	pop	rax
-	mov	rax, [rax]
-	cmp	eax, 123456
-	jne	failure
-
-	ok
-
 	call code_buffer_deinit
 
 	ret

--- a/dictionary.inc
+++ b/dictionary.inc
@@ -31,7 +31,7 @@ _core_words:
 	db	0
 	dd	0
 	dq	0
-	dq	_core_code.b_comma
+	dq	b_comma
 	dq	'b,'
 	dq	_AL
 	; TODO: clobbers rdi
@@ -43,7 +43,7 @@ _core_words:
 	db	0
 	dd	0
 	dq	.b_comma
-	dq	_core_code.d_comma
+	dq	d_comma
 	dq	'd,'
 	dq	_EAX
 	; TODO: clobbers rdi
@@ -56,7 +56,7 @@ _core_words:
 	db	0
 	dd	0
 	dq	.d_comma
-	dq	_core_code.base
+	dq	base
 	dq	'base'
 	dq	_AL
 
@@ -157,4 +157,32 @@ word_input_stack_effects:
 
 	lea	esi, [eax + _dictionary.word_offset + esi]
 	
+	ret
+
+;
+; expects
+;	- value in al
+;
+b_comma:
+	mov	rdi, [_code_buffer.here]
+	stosb
+	mov	[_code_buffer.here], rdi
+	ret
+
+;
+; expects
+;	- value in eax
+;
+d_comma:
+	mov	rdi, [_code_buffer.here]
+	stosd
+	mov	[_code_buffer.here], rdi
+	ret
+
+;
+; expects
+;	- value in al
+;
+base:
+	mov	[_blue.base], al
 	ret

--- a/dictionary_test.inc
+++ b/dictionary_test.inc
@@ -54,11 +54,58 @@ dictionary_test:
 	jne	failure
 
 	ok
+	
+	t 'b, writes a byte'
+
+	mov	al, 123
+	call	b_comma
+	
+	mov	rax, [_code_buffer.base]
+	mov	rcx, [_code_buffer.here]
+	sub	rcx, rax
+	cmp	ecx, 1
+	jne	failure
+	push	rax
+
+	ok
+
+	t 'b, writes the correct value'
+
+	pop	rax
+	mov	rax, [rax]
+	cmp	al, 123
+	jne	failure
+
+	ok
+
+	t 'd, writes a dword'
+	
+	mov	eax, 123456
+	call	d_comma
+
+	mov	rax, [_code_buffer.base]
+	inc	rax
+	mov	rcx, [_code_buffer.here]
+	sub	rcx, rax
+	cmp	ecx, 4
+	jne	failure
+	push	rax
+
+	ok
+
+	t 'd, writes the correct value'
+
+	pop	rax
+	mov	rax, [rax]
+	cmp	eax, 123456
+	jne	failure
+
+	ok
 
 	tc1	unknown, 4, 0
-	tc1	b_comma, 2, _core_words.b_comma
-	tc1	d_comma, 2, _core_words.d_comma
-	tc1	base, 4, _core_words.base
+	tc1	word_b_comma, 2, _core_words.b_comma
+	tc1	word_d_comma, 2, _core_words.d_comma
+	tc1	word_base, 4, _core_words.base
 
 	tc2	_core_words.b_comma, 1, 8
 	
@@ -67,6 +114,6 @@ dictionary_test:
 	ret
 
 unknown		db '!@#$'
-b_comma		db 'b,'
-d_comma		db 'd,'
-base		db 'base'
+word_b_comma	db 'b,'
+word_d_comma	db 'd,'
+word_base	db 'base'

--- a/flow.inc
+++ b/flow.inc
@@ -21,10 +21,10 @@ flow_in:
 
 	mov	al, 0xb8
 	add	al, bl
-	call	_core_code.b_comma
+	call	b_comma
 
 	call	data_stack_pop
-	call	_core_code.d_comma
+	call	d_comma
 
 	jmp	.loop
 

--- a/kernel.inc
+++ b/kernel.inc
@@ -74,7 +74,7 @@ _interpretive_dance:
 	je	.done
 	
 	mov	al, 0xc3
-	call	_core_code.b_comma
+	call	b_comma
 
 	mov	rsi, [_code_buffer.mark]
 	mov	rdi, rsi
@@ -106,21 +106,21 @@ _handle_word:
 	call	flow_in
 
 	mov	al, 0x48
-	call	_core_code.b_comma
+	call	b_comma
 	mov	al, 0xc7
-	call	_core_code.b_comma
+	call	b_comma
 	mov	al, 0xc7
-	call	_core_code.b_comma
+	call	b_comma
 
 	pop	rax
 	add	rax, _dictionary.code_offset
 	mov	rax, [rax]
-	call	_core_code.d_comma
+	call	d_comma
 
 	mov	al, 0xff
-	call	_core_code.b_comma
+	call	b_comma
 	mov	al, 0xd7
-	call	_core_code.b_comma
+	call	b_comma
 
 	pop	rax
 	call	flow_out


### PR DESCRIPTION
Doesn't really belong there. Originally I planned to copy all the core code into the code buffer but that is not required for compile time execution.