### PR TITLE
Allow specifying a word as the program entry point

### DIFF
--- a/dictionary.inc
+++ b/dictionary.inc
@@ -62,7 +62,6 @@ _core_words:
 	dq	semi
 	dq	';'
 	
-	.latest:
 	.base:
 	db	0, 4, 1, 0
 	dd	0
@@ -70,6 +69,14 @@ _core_words:
 	dq	base
 	dq	'base'
 	dq	_AL
+
+	.latest:
+	.entry:
+	db	DE_IMMEDIATE, 5, 0, 0
+	dd	0
+	dq	.base
+	dq	_entry
+	dq	'entry'
 
 assert ($ - _core_words) and 7 = 0
 
@@ -323,3 +330,11 @@ semi:
 
 	ret
 
+_entry:
+	mov	rax, [_dictionary.latest]
+	add	rax, _dictionary.code_offset
+	mov	rax, [rax]
+	sub	rax, [_code_buffer.base]
+	mov	[_blue.entry], eax
+
+	ret

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -209,5 +209,5 @@ entry_18:
 	.blue_length = $ - .blue
 
 	.expected:
-	dd	18
+	dd	0x12
 	

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -61,6 +61,41 @@ macro tc2 what {
 	call	kernel_deinit
 }
 
+macro tc3 what {
+	call	kernel_init
+
+	mov	rsi, what##.blue
+	mov	ecx, what##.blue_length
+	xor	eax, eax
+
+	call	kernel_loop
+
+	t 'parsed blue successfully'
+	
+	cmp	eax, SUCCESS
+	jne	failure
+
+	ok
+
+	t 'has the expected mode'
+	
+	cmp	[_blue.mode], INTERPRET
+	jne	failure
+
+	ok
+
+	t 'has the expected entry'
+	
+	mov	ecx, [what##.expected]
+	mov	eax, [_blue.entry]
+	cmp	eax, ecx
+	jne	failure
+	
+	ok
+	
+	call	kernel_deinit
+}
+
 kernel_test:
 	call kernel_init
 
@@ -96,7 +131,10 @@ kernel_test:
 	tc1	user_one_byte
 	
 	tc2	bogus
-		
+
+	tc3	entry_0
+	tc3	entry_18
+	
 	ret
 
 bogus:
@@ -155,3 +193,21 @@ user_one_byte:
 	.expected:
 	db	0x01
 	.expected_length = $ - .expected
+
+entry_0:
+	.blue:
+	db	': 1b 1 b, ; entry '
+	.blue_length = $ - .blue
+
+	.expected:
+	dd	0x00
+
+entry_18:
+	.blue:
+	db	': 1b 1 b, ; '
+	db	': _start ; entry '
+	.blue_length = $ - .blue
+
+	.expected:
+	dd	18
+	


### PR DESCRIPTION
Prior the execution would always start at the beginning of the code buffer. Now that we have user defined words, allow setting one as the entry point for the program.