### PR TITLE
Add debug.inc to check code buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DEV_DOCKER_FILE ?= dev.Dockerfile
 DEV_IMAGE ?= blue-dev
 
 IN_DEV_CONTAINER ?= docker exec $(DEV_CONTAINER)
-DISASM ?= $(IN_DEV_CONTAINER) objdump $(ARGS) -D -M intel -m i386:x86-64
+DISASM ?= $(IN_DEV_CONTAINER) objdump -D -M intel -m i386:x86-64 $(ARGS)
 
 FASM ?= fasm
 
@@ -36,9 +36,17 @@ run:
 dis:
 	$(DISASM) $(WHAT)
 
+disb: ARGS=-b binary
+disb: dis
+	@true
+
+discb: WHAT=code_buffer_dump.out
+discb: disb
+	@true
+
 clean:
 	rm -f $(BLUE) *.out
 	
 .PHONY:
 	dev-env dev-start dev-stop \
-	compile run dis clean
+	compile run dis disb discb clean

--- a/blue.asm
+++ b/blue.asm
@@ -16,6 +16,7 @@ include "flow.inc"
 include "parser.inc"
 include "to_number.inc"
 include "kernel.inc"
+include "debug.inc"
 
 entry $
 	call	kernel_init
@@ -28,6 +29,8 @@ entry $
 
 	cmp	eax, SUCCESS
 	jne	.exit
+
+	call	dump_code_buffer
 	
 	;
 	; write the output to ./a.out

--- a/blue_test.asm
+++ b/blue_test.asm
@@ -25,6 +25,7 @@ include "dictionary.inc"
 include	"flow.inc"
 include "kernel.inc"
 include "elf.inc"
+include "debug.inc"
 
 macro t what {
 	inc	[test_num]

--- a/code_buffer_test.inc
+++ b/code_buffer_test.inc
@@ -46,26 +46,3 @@ check_code_buffer:
 	call	dump_code_buffer
 	jmp	failure
 
-dump_code_buffer:
-	mov	rdi, _code_buffer_dump_file
-	mov	esi, 0x01 or 0x40 or 0x200
-	mov	edx, 0x1ed
-	mov	eax, SYS_OPEN
-	syscall
-
-	mov	rdi, rax
-	mov	rsi, [_code_buffer.base]
-	mov	rdx, [_code_buffer.here]
-	sub	rdx, rsi
-	mov	eax, SYS_WRITE
-	syscall
-	
-	mov	eax, SYS_CLOSE
-	syscall
-	
-	ret
-
-_code_buffer_dump_file:
-	db	"code_buffer_dump.out"
-	db	0x00
-

--- a/debug.inc
+++ b/debug.inc
@@ -1,0 +1,23 @@
+
+dump_code_buffer:
+	mov	rdi, _code_buffer_dump_file
+	mov	esi, 0x01 or 0x40 or 0x200
+	mov	edx, 0x1ed
+	mov	eax, SYS_OPEN
+	syscall
+
+	mov	rdi, rax
+	mov	rsi, [_code_buffer.base]
+	mov	rdx, [_code_buffer.here]
+	sub	rdx, rsi
+	mov	eax, SYS_WRITE
+	syscall
+	
+	mov	eax, SYS_CLOSE
+	syscall
+	
+	ret
+
+_code_buffer_dump_file:
+	db	"code_buffer_dump.out"
+	db	0x00

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -122,13 +122,12 @@ kernel_test:
 	
 	call	kernel_deinit
 
-	tc1	user_one_byte
-
 	tc1	one_byte
 	tc1	two_bytes
 	tc1	one_byte_base16
 	tc1	clean_exit
 	tc1	user_one_byte
+	tc1	user_empty_words
 	
 	tc2	bogus
 
@@ -210,4 +209,19 @@ entry_18:
 
 	.expected:
 	dd	0x12
+	
+user_empty_words:
+	.blue:
+	db	'16 base '
+	db	'90 b, 90 b, 90 b, '
+	db	': x ; '
+	db	': y ; '
+	db	': z ; '
+	db	'x y z '
+	.blue_length = $ - .blue
+
+	.expected:
+	db	0x90, 0x90, 0x90
+	db	0xc3, 0xc3, 0xc3
+	.expected_length = $ - .expected
 	


### PR DESCRIPTION
Also added a test just to confirm. Made it easier to disassemble either a flat binary or elf output. Dumping the code buffer when compiling for right now just to ease debugging.