### PR TITLE
Support calling user words from other user words

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,15 @@ compile:
 	$(IN_DEV_CONTAINER) $(FASM) $(WHAT).asm $(WHAT) && chmod +x $(WHAT)
 
 run:
-	$(IN_DEV_CONTAINER) ./$(WHAT)
+	$(IN_DEV_CONTAINER) ./$(WHAT) && ./a.out
 
 dis:
 	$(DISASM) $(WHAT)
 
+disa: WHAT=a.out
+disa: dis
+	@true
+	
 disb: ARGS=-b binary
 disb: dis
 	@true
@@ -49,4 +53,5 @@ clean:
 	
 .PHONY:
 	dev-env dev-start dev-stop \
-	compile run dis disb discb clean
+	compile run clean \
+	dis disa disb discb

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ compile:
 	$(IN_DEV_CONTAINER) $(FASM) $(WHAT).asm $(WHAT) && chmod +x $(WHAT)
 
 run:
-	$(IN_DEV_CONTAINER) ./$(WHAT) && ./a.out
+	$(IN_DEV_CONTAINER) ./$(WHAT)
 
 dis:
 	$(DISASM) $(WHAT)

--- a/blue.asm
+++ b/blue.asm
@@ -63,11 +63,13 @@ segment readable
 blue_bye:
 	db	'16 base '
 	db	''
-	db	': bye '
-	db	'	31 b, FF b, '
-	db	'	B8 b, 3C d, '
-	db	'	0F b, 05 b, '
-	db	'; immediate '
+	db	': xor-edi 31 b, FF b, ; '
+	db	': mov-eax-60 B8 b, 3C d, ; '
+	db	': syscall 0F b, 05 b, ; '
+	db	''
+	db	': ok xor-edi ; '
+	db	': exit mov-eax-60 syscall ; '
+	db	': bye ok exit ; immediate '
 	db	''
 	db	': _start bye ; entry '
 	.length = $ - blue_bye

--- a/blue_test.asm
+++ b/blue_test.asm
@@ -89,37 +89,8 @@ failure:
 	mov	eax, 60
 	syscall
 
-print_char:
-	mov	edx, 1
-
-print:
-	mov	edi, STDOUT_FILENO
-	mov	eax, SYS_WRITE
-	syscall
-	ret
-
-here:
-	push	rax
-	push	rcx
-	push	rdi
-	push	rdx
-	push	rsi
-	
-	mov	esi, H
-	call	print_char
-
-	pop	rsi
-	pop	rdx
-	pop	rdi
-	pop	rcx
-	pop	rax
-
-	ret
-	
-newline db 10
 dot db '.'
 X db 'X'
-H db 'H'
 ts_ok db ' ok', 10
 
 header:

--- a/debug.inc
+++ b/debug.inc
@@ -21,3 +21,60 @@ dump_code_buffer:
 _code_buffer_dump_file:
 	db	"code_buffer_dump.out"
 	db	0x00
+
+H db 'H'
+newline db 10
+
+print_char:
+	mov	edx, 1
+
+print:
+	mov	edi, STDOUT_FILENO
+	mov	eax, SYS_WRITE
+	syscall
+	ret
+
+print_word:
+	push	rax
+	push	rcx
+	push	rdi
+	push	rdx
+	push	rsi
+
+	xor	edx, edx
+	mov	dl, [_blue.word_len]
+	mov	esi, _blue.word
+	call	print
+
+	mov	esi, newline
+	call	print_char
+
+	pop	rsi
+	pop	rdx
+	pop	rdi
+	pop	rcx
+	pop	rax
+
+	ret
+	
+here:
+	push	rax
+	push	rcx
+	push	rdi
+	push	rdx
+	push	rsi
+	
+	mov	esi, H
+	call	print_char
+
+	mov	esi, newline
+	call	print_char
+
+	pop	rsi
+	pop	rdx
+	pop	rdi
+	pop	rcx
+	pop	rax
+
+	ret
+

--- a/dictionary.inc
+++ b/dictionary.inc
@@ -13,6 +13,7 @@
 
 DE_HIDDEN		= 1
 DE_IMMEDIATE		= 2
+DE_CORE			= 4
 
 FLAGS_OFFSET		= 0
 FLAGS_MASK		= 0xff
@@ -25,7 +26,7 @@ IN_EFFECTS_LEN_MASK	= 0x0000ff
 
 macro __w word, word_len, flags, code, ise_len, ose_len {
 	.##code:
-	db	flags, word_len, ise_len, ose_len
+	db	flags or DE_CORE, word_len, ise_len, ose_len
 	dd	0
 	dq	_core_words.prev_word
 	dq	code

--- a/kernel.inc
+++ b/kernel.inc
@@ -63,7 +63,7 @@ kernel_deinit:
 ; expects
 ;	- word in rax
 ;
-_compile_word:
+_compile_word_abs:
 	push	rax
 	call	flow_in
 
@@ -76,11 +76,6 @@ _compile_word:
 	add	rax, _dictionary.code_offset
 	mov	rax, [rax]
 
-	cmp	rax, _code_buffer.base
-	jl	.c
-
-	
-	.c:
 	call	q_comma
 
 	mov	al, 0xff
@@ -94,28 +89,32 @@ _compile_word:
 ; expects
 ;	- word in rax
 ;
-_interpret_word:
-	push	[_code_buffer.here]
-
+_compile_word_rel:
 	push	rax
 	call	flow_in
 
-	mov	al, 0x48
-	call	b_comma
-	mov	al, 0xbf
+	mov	al, 0xe8
 	call	b_comma
 
 	pop	rax
 	add	rax, _dictionary.code_offset
 	mov	rax, [rax]
+	sub	rax, [_code_buffer.here]
+	sub	rax, 4
 
-	call	q_comma
+	call	d_comma
 
-	mov	al, 0xff
-	call	b_comma
-	mov	al, 0xd7
-	call	b_comma
+	ret
 
+;
+; expects
+;	- word in rax
+;
+_interpret_word:
+	push	[_code_buffer.here]
+
+	call	_compile_word_abs
+	
 	mov	al, 0xc3
 	call	b_comma
 
@@ -136,12 +135,17 @@ _handle_word:
 	mov	rsi, [rax]
 	test	sil, DE_IMMEDIATE
 	jnz	.interpret
+	
+	test	sil, DE_CORE
+	jnz	.compile_core
 
-	call	_compile_word
-	jmp	.done
+	call	_compile_word_rel
+	ret
+	
+	.compile_core:
+	call	_compile_word_abs
+	ret
 
 	.interpret:
 	call	_interpret_word
-
-	.done:
 	ret

--- a/kernel.inc
+++ b/kernel.inc
@@ -76,6 +76,11 @@ _compile_word:
 	add	rax, _dictionary.code_offset
 	mov	rax, [rax]
 
+	cmp	rax, _code_buffer.base
+	jl	.c
+
+	
+	.c:
 	call	q_comma
 
 	mov	al, 0xff
@@ -92,7 +97,24 @@ _compile_word:
 _interpret_word:
 	push	[_code_buffer.here]
 
-	call	_compile_word
+	push	rax
+	call	flow_in
+
+	mov	al, 0x48
+	call	b_comma
+	mov	al, 0xbf
+	call	b_comma
+
+	pop	rax
+	add	rax, _dictionary.code_offset
+	mov	rax, [rax]
+
+	call	q_comma
+
+	mov	al, 0xff
+	call	b_comma
+	mov	al, 0xd7
+	call	b_comma
 
 	mov	al, 0xc3
 	call	b_comma


### PR DESCRIPTION
There was a bug where the address compiled to call a user word from a user word at runtime would be the address from compile time, resulting in a segfault. For runtime calls we can use a relative offset within the code buffer in this case. Compile time calls still use the absolute address to support calling user code or compiler code while compiling.