### PR TITLE
First pass at parsing input stack effects

### DIFF
--- a/blue_test.asm
+++ b/blue_test.asm
@@ -84,6 +84,8 @@ failure:
 
 	mov	esi, newline
 	call	print_char
+
+	call	dump_code_buffer
 	
 	mov	dil, [test_num]
 	mov	eax, 60

--- a/code_buffer_test.inc
+++ b/code_buffer_test.inc
@@ -43,6 +43,5 @@ check_code_buffer:
 	.failure_length:
 	.failure_byte:
 
-	call	dump_code_buffer
 	jmp	failure
 

--- a/dictionary.inc
+++ b/dictionary.inc
@@ -423,5 +423,3 @@ se_reg_eax:
 	stosb
 	
 	ret
-die 9
-	ret

--- a/dictionary.inc
+++ b/dictionary.inc
@@ -412,5 +412,16 @@ seX_parse_end:
 	ret
 
 se_reg_eax:
-	die 9
+	mov	rax, _EAX
+	mov	rdi, [_dictionary.here]
+	stosq
+
+	mov	rdi, [_dictionary.latest]
+	add	rdi, 2
+	mov	al, byte [rdi]
+	inc	al
+	stosb
+	
+	ret
+die 9
 	ret

--- a/dictionary.inc
+++ b/dictionary.inc
@@ -58,10 +58,15 @@ macro _ose e {
 _core_words:
 	.prev_word = 0
 
+	_wi	'eax', 3, se_reg_eax, 0, 0
+
+	.se_reg_latest = .prev_word
+	.prev_word = 0
+
 	_wi	'--', 2, seX_o_parse, 0, 0
 	_wi	'))', 2, seX_parse_end, 0, 0
 
-	.se_latest = .prev_word
+	.se_parse_latest = .prev_word
 	.prev_word = 0
 	
 	_w	'b,', 2, b_comma, 1, 0
@@ -364,20 +369,33 @@ seX_i_parse:
 	cmp	[_blue.word_len], 0
 	je	se_bad
 
-	mov	rdi, _core_words.se_latest
+	mov	rdi, _core_words.se_parse_latest
 	call	_find_from
 
 	cmp	rax, _core_words.seX_o_parse
 	je	seX_o_parse
 
-	jmp	se_bad
+	call	parser_next_word
+	cmp	[_blue.word_len], 0
+	je	se_bad
+
+	mov	rdi, _core_words.se_reg_latest
+	call	_find_from
+
+	test	rax, rax
+	jz	se_bad
+
+	add	rax, _dictionary.code_offset
+	call	qword [rax]
+	
+	jmp	seX_i_parse
 	
 seX_o_parse:
 	call	parser_next_word
 	cmp	[_blue.word_len], 0
 	je	se_bad
 
-	mov	rdi, _core_words.se_latest
+	mov	rdi, _core_words.se_parse_latest
 	call	_find_from
 
 	cmp	rax, _core_words.seX_parse_end
@@ -391,4 +409,8 @@ seX_parse_end:
 	or	al, DE_SE_KNOWN
 	stosb
 
+	ret
+
+se_reg_eax:
+	die 9
 	ret

--- a/flow.inc
+++ b/flow.inc
@@ -4,16 +4,16 @@
 ;
 flow_in:
 	call	word_input_stack_effects
-	mov	edi, esi
+	mov	rdi, rsi
 
 	.loop:
 	dec	ecx
 	js	.done
 
-	lea	ebx, [edi + (ecx * 8)]
-	mov	ebx, [ebx]
-	and	ebx, REG_MASK
-	shr	ebx, REG_OFFSET
+	lea	rbx, [rdi + (rcx * 8)]
+	mov	rbx, [rbx]
+	and	rbx, REG_MASK
+	shr	rbx, REG_OFFSET
 
 	call	data_stack_pop
 	cmp	eax, _IMMEDIATE

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -129,6 +129,7 @@ kernel_test:
 	tc1	user_one_byte
 	tc1	user_empty_words
 	tc1	seX_empty
+	tc1	ise_1
 	
 	tc2	bogus
 
@@ -202,6 +203,18 @@ seX_empty:
 
 	.expected:
 	db	0x01
+	.expected_length = $ - .expected
+
+ise_1:
+	.blue:
+	db	': syscall (( num eax -- )) 15 b, 5 b, ; '
+	db	'60 syscall'
+	.blue_length = $ - .blue
+
+	.expected:
+	db	0xb8
+	dd	0xc3
+	db	0x0f, 0x05
 	.expected_length = $ - .expected
 
 entry_0:

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -207,14 +207,17 @@ seX_empty:
 
 ise_1:
 	.blue:
-	db	': syscall (( num eax -- )) 15 b, 5 b, ; '
-	db	'60 syscall'
+	db	': syscall (( num eax -- )) ; '
+	db	': _ (( -- )) 60 syscall ; entry '
 	.blue_length = $ - .blue
 
 	.expected:
+	db	0xc3
 	db	0xb8
-	dd	0xc3
-	db	0x0f, 0x05
+	dd	0x3c
+	db	0xe8
+	db	0xf5, 0xff, 0xff, 0xff
+	db	0xc3
 	.expected_length = $ - .expected
 
 entry_0:

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -208,7 +208,7 @@ seX_empty:
 ise_1:
 	.blue:
 	db	': syscall (( num eax -- )) ; '
-	db	': _ (( -- )) 60 syscall ; entry '
+	db	': _ 60 syscall ; entry '
 	.blue_length = $ - .blue
 
 	.expected:


### PR DESCRIPTION
Adds another segment to the dictionary for handling the register specifications for input stack effects. Currently only `eax` is defined. Needs some more thought into how this will work with `b,`, immediate words, postpone, etc. This does at least illustrate the theory.