### PR TITLE
More work on handling input stack effects

### DIFF
--- a/blue_test.asm
+++ b/blue_test.asm
@@ -64,12 +64,12 @@ entry $
 	mov	edx, header.length
 	call	print
 
-	;ts	code_buffer
-	;ts	data_stack
-	;ts	parser
-	;ts	to_number
-	;ts	dictionary
-	;ts	flow
+	ts	code_buffer
+	ts	data_stack
+	ts	parser
+	ts	to_number
+	ts	dictionary
+	ts	flow
 	ts	kernel
 	ts	elf
 

--- a/blue_test.asm
+++ b/blue_test.asm
@@ -64,12 +64,12 @@ entry $
 	mov	edx, header.length
 	call	print
 
-	ts	code_buffer
-	ts	data_stack
-	ts	parser
-	ts	to_number
-	ts	dictionary
-	ts	flow
+	;ts	code_buffer
+	;ts	data_stack
+	;ts	parser
+	;ts	to_number
+	;ts	dictionary
+	;ts	flow
 	ts	kernel
 	ts	elf
 

--- a/dictionary.inc
+++ b/dictionary.inc
@@ -409,6 +409,9 @@ seX_parse_end:
 	or	al, DE_SE_KNOWN
 	stosb
 
+	mov	rax, [_dictionary.latest]
+	call	push_flow_in
+
 	ret
 
 se_reg_eax:

--- a/flow.inc
+++ b/flow.inc
@@ -29,7 +29,6 @@ flow_in:
 	jmp	.loop
 
 	.flow_reg:
-	die	ERR_NO_IMPL
 	
 	.done:
 	ret

--- a/flow.inc
+++ b/flow.inc
@@ -30,6 +30,22 @@ flow_in:
 	jmp	.loop
 
 	.flow_reg:
+	and	ebx, 7
+	shl	ebx, 3
+	
+	and	rax, REG_MASK
+	shr	rax, REG_OFFSET
+	and	eax, 7
+
+	or	ebx, eax
+	or	ebx, 0xc0
+
+	mov	al, 0x89
+	call	b_comma
+
+	mov	al, bl
+	call	b_comma
+	
 	jmp	.loop
 	
 	.done:

--- a/flow.inc
+++ b/flow.inc
@@ -19,6 +19,7 @@ flow_in:
 	cmp	eax, _IMMEDIATE
 	jne	.flow_reg
 
+	.flow_lit:
 	mov	al, 0xb8
 	add	al, bl
 	call	b_comma
@@ -29,10 +30,32 @@ flow_in:
 	jmp	.loop
 
 	.flow_reg:
+	jmp	.loop
 	
 	.done:
 	ret
 
+;
+; expects
+;	- word in rax
+;
+push_flow_in:
+	call	word_input_stack_effects
+
+	.loop:
+	dec	ecx
+	js	.done
+
+	lea	rax, [rsi + (rcx * 8)]
+	mov	rax, [rax]
+	and	rax, REG_MASK
+	shr	rax, REG_OFFSET
+
+	call	data_stack_push
+	
+	.done:
+	ret
+	
 ;
 ; expects
 ;	- word in rax

--- a/flow.inc
+++ b/flow.inc
@@ -64,10 +64,9 @@ push_flow_in:
 
 	lea	rax, [rsi + (rcx * 8)]
 	mov	rax, [rax]
-	and	rax, REG_MASK
-	shr	rax, REG_OFFSET
 
 	call	data_stack_push
+	jmp	.loop
 	
 	.done:
 	ret

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -223,7 +223,7 @@ ise_1:
 
 ise_2:
 	.blue:
-	db	': syscall (( num eax -- )) d, ; immediate '
+	db	': syscall (( num ecx -- )) d, ; '
 	db	': _ 7 syscall ; entry '
 	.blue_length = $ - .blue
 

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -122,20 +122,20 @@ kernel_test:
 	
 	call	kernel_deinit
 
-	tc1	one_byte
-	tc1	two_bytes
-	tc1	one_byte_base16
-	tc1	clean_exit
-	tc1	user_one_byte
-	tc1	user_empty_words
-	tc1	seX_empty
-	tc1	ise_1
+	;tc1	one_byte
+	;tc1	two_bytes
+	;tc1	one_byte_base16
+	;tc1	clean_exit
+	;tc1	user_one_byte
+	;tc1	user_empty_words
+	;tc1	seX_empty
+	;tc1	ise_1
 	tc1	ise_2
 	
-	tc2	bogus
+	;tc2	bogus
 
-	tc3	entry_0
-	tc3	entry_18
+	;tc3	entry_0
+	;tc3	entry_18
 	
 	ret
 
@@ -224,15 +224,12 @@ ise_1:
 ise_2:
 	.blue:
 	db	': syscall (( num eax -- )) d, ; immediate '
-	db	': _ 60 syscall ; entry '
+	db	': _ 7 syscall ; entry '
 	.blue_length = $ - .blue
 
 	.expected:
 	db	0xc3
-	db	0xb8
-	dd	0x3c
-	db	0xe8
-	db	0xf5, 0xff, 0xff, 0xff
+	dd	0x07
 	db	0xc3
 	.expected_length = $ - .expected
 

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -122,20 +122,20 @@ kernel_test:
 	
 	call	kernel_deinit
 
-	;tc1	one_byte
-	;tc1	two_bytes
-	;tc1	one_byte_base16
-	;tc1	clean_exit
-	;tc1	user_one_byte
-	;tc1	user_empty_words
-	;tc1	seX_empty
-	;tc1	ise_1
+	tc1	one_byte
+	tc1	two_bytes
+	tc1	one_byte_base16
+	tc1	clean_exit
+	tc1	user_one_byte
+	tc1	user_empty_words
+	tc1	seX_empty
+	tc1	ise_1
 	tc1	ise_2
 	
-	;tc2	bogus
+	tc2	bogus
 
-	;tc3	entry_0
-	;tc3	entry_18
+	tc3	entry_0
+	tc3	entry_18
 	
 	ret
 

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -223,8 +223,8 @@ ise_1:
 
 ise_2:
 	.blue:
-	db	': syscall (( num ecx -- )) d, ; '
-	db	': _ 7 syscall ; entry '
+	db	': myd, (( num eax -- )) d, ; immediate '
+	db	': _ 7 myd, ; entry '
 	.blue_length = $ - .blue
 
 	.expected:

--- a/kernel_test.inc
+++ b/kernel_test.inc
@@ -130,6 +130,7 @@ kernel_test:
 	tc1	user_empty_words
 	tc1	seX_empty
 	tc1	ise_1
+	tc1	ise_2
 	
 	tc2	bogus
 
@@ -208,6 +209,21 @@ seX_empty:
 ise_1:
 	.blue:
 	db	': syscall (( num eax -- )) ; '
+	db	': _ 60 syscall ; entry '
+	.blue_length = $ - .blue
+
+	.expected:
+	db	0xc3
+	db	0xb8
+	dd	0x3c
+	db	0xe8
+	db	0xf5, 0xff, 0xff, 0xff
+	db	0xc3
+	.expected_length = $ - .expected
+
+ise_2:
+	.blue:
+	db	': syscall (( num eax -- )) d, ; immediate '
 	db	': _ 60 syscall ; entry '
 	.blue_length = $ - .blue
 


### PR DESCRIPTION
In theory will allow movs between the first seven registers, very lightly tested due to what appears to be a dictionary lookup issue.