### PR TITLE
VM Memory layout tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ The BlueVM has the following layout in rwx memory:
 1. Input buffer (2048 bytes)
 1. Return stack (512 bytes)
 1. Data stack (512 bytes)
-1. Padding (1024 bytes)
-1. Runtime Buffer (4096 bytes)
+1. Runtime Data (1024 bytes)
+   1. User defined (960 bytes)
    1. BlueVM addresses (64 bytes)
-   1. Code Buffer (4032 bytes)
+1. Code Buffer (4096 bytes)
 
 ## Boot
 
@@ -145,3 +145,6 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Add bytecode opcodes for litb, etc
 1. Print error messages to disambiguate exit status
 1. Move to fasm2
+1. BlueVM as a fasmg target
+   1. Look at blang being done this way
+   1. Find the page that has all the links for the different fasmg scripts

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The BlueVM has the following layout in rwx memory:
    1. BlueVM Opcode Map: 0x00 - 0x7F (2048 bytes)
    1. Extended Opcode Map: 0x80 - 0xFF (2048 bytes)
 1. Input buffer (2048 bytes)
-1. Return stack (1024 bytes)
-1. Data stack (1024 bytes)
+1. Return stack (512 bytes)
+1. Data stack (512 bytes)
+1. Padding (1024 bytes)
 1. Runtime Buffer (4096 bytes)
    1. BlueVM addresses (64 bytes)
    1. Code Buffer (4032 bytes)
@@ -143,4 +144,4 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Add bytecode op if/if-not
 1. Add bytecode opcodes for litb, etc
 1. Print error messages to disambiguate exit status
-1. Move blang into lang like blue
+1. Move to fasm2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The BlueVM has the following layout in rwx memory:
 1. Return stack (512 bytes)
 1. Data stack (512 bytes)
 1. Runtime Data (1024 bytes)
-   1. User defined (960 bytes)
+   1. User data (960 bytes)
    1. BlueVM addresses (64 bytes)
 1. Code Buffer (4096 bytes)
 
@@ -147,4 +147,4 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Move to fasm2
 1. BlueVM as a fasmg target
    1. Look at blang being done this way
-   1. Find the page that has all the links for the different fasmg scripts
+   1. Examples - https://board.flatassembler.net/topic.php?t=19389

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -7,9 +7,14 @@ OPCODE_TBL_SIZE = 4096
 INPUT_BUFFER_SIZE = 2048
 RETURN_STACK_SIZE = 512
 DATA_STACK_SIZE = 512
-PADDING_SIZE = 1024
+RUNTIME_DATA_SIZE = 1024
 VM_ADDRS_SIZE = 64
-CODE_BUFFER_SIZE = (4096 - VM_ADDRS_SIZE)
+USER_DATA_SIZE = RUNTIME_DATA_SIZE - VM_ADDRS_SIZE
+CODE_BUFFER_SIZE = 4096
+
+STACKS_SIZE = RETURN_STACK_SIZE + DATA_STACK_SIZE
+BUFFERS_SIZE = INPUT_BUFFER_SIZE + CODE_BUFFER_SIZE
+VM_MEM_SIZE = OPCODE_TBL_SIZE + BUFFERS_SIZE + STACKS_SIZE + RUNTIME_DATA_SIZE
 
 OPCODE_HANDLER_COMPILE = opcode_handler_compile
 OPCODE_HANDLER_INTERPRET = opcode_handler_interpret
@@ -74,26 +79,31 @@ entry $
 include "opcodes.inc"
 rb (OPCODE_TBL_SIZE - ($ - opcode_tbl))
 
-instruction_pointer rq 1
-opcode_handler rq 1
-opcode_handler_invalid rq 1
-
 input_buffer rb INPUT_BUFFER_SIZE
 
 return_stack rb RETURN_STACK_SIZE
-return_stack_here rq 1
-return_stack_size rq 1
-
 data_stack rb DATA_STACK_SIZE
-data_stack_here rq 1
-data_stack_size rq 1
 
-padding rb PADDING_SIZE
+user_data rb USER_DATA_SIZE
 
 vm_addrs:
 vm_addr_opcode_handler_call rq 1
 rb (VM_ADDRS_SIZE - ($ - vm_addrs))
 
-code_buffer rb (CODE_BUFFER_SIZE - VM_ADDRS_SIZE)
+code_buffer rb CODE_BUFFER_SIZE
+
+assert ($ - opcode_tbl) = VM_MEM_SIZE
+
+instruction_pointer rq 1
+
+opcode_handler rq 1
+opcode_handler_invalid rq 1
+
+return_stack_here rq 1
+return_stack_size rq 1
+
+data_stack_here rq 1
+data_stack_size rq 1
+
 code_buffer_here rq 1
 code_buffer_size rq 1

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -5,8 +5,9 @@ CELL_SIZE = 8
 
 OPCODE_TBL_SIZE = 4096
 INPUT_BUFFER_SIZE = 2048
-RETURN_STACK_SIZE = 1024
-DATA_STACK_SIZE = 1024
+RETURN_STACK_SIZE = 512
+DATA_STACK_SIZE = 512
+PADDING_SIZE = 1024
 VM_ADDRS_SIZE = 64
 CODE_BUFFER_SIZE = (4096 - VM_ADDRS_SIZE)
 
@@ -86,6 +87,8 @@ return_stack_size rq 1
 data_stack rb DATA_STACK_SIZE
 data_stack_here rq 1
 data_stack_size rq 1
+
+padding rb PADDING_SIZE
 
 vm_addrs:
 vm_addr_opcode_handler_call rq 1


### PR DESCRIPTION
Cut data and return stack sizes in half, add a user data space and return the code buffer to the full 4096 bytes. Move internal pointers to after the vm mem so that it is actually grouped as the README describes.