### PR TITLE
Slowly introduce TAP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ "main" ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "tap" ]
 
 jobs:
   build:
@@ -16,3 +16,5 @@ jobs:
         submodules: recursive
     - name: make
       run: make
+    - name: prove
+      run: prove lang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ "main" ]
   push:
-    branches: [ "main", "tap" ]
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -16,5 +16,3 @@ jobs:
         submodules: recursive
     - name: make
       run: make
-    - name: prove
-      run: prove lang

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,14 @@ GEN_FILES = $(BLUEVM_OPS_TBL) $(README)
 LANGS = lang/blasm
 TOOLS = tools/bth
 
-.PHONY: all clean $(LANGS) $(TOOLS)
+.PHONY: all clean test $(LANGS) $(TOOLS)
 
 all: $(BLUEVM) \
 	$(GEN_FILES) \
 	$(LANGS) \
 	$(TOOLS) \
-	$(TEST_OBJS)
+	$(TEST_OBJS) \
+	test
 
 clean: $(LANGS) $(TOOLS)
 	rm -rf bin obj $(GEN_FILES)
@@ -33,8 +34,11 @@ $(BLUEVM_OPS_TBL): $(BLUEVM_OPS_INC)
 $(LANGS) $(TOOLS):
 	$(MAKE) -C $@ $(MAKECMDGOALS) || exit
 
-obj/test_%.bs0: test/%.bla $(BLASM) $(BTH) | obj
-	$(BLASM) -n $< $@ && $(BTH) < $@
+obj/test_%.bs0: test/%.bla $(BLASM) | obj
+	$(BLASM) -n $< $@
+
+test: $(TOOLS)
+	$(PROVE) obj/test_*
 	
 $(README): $(README).sh $(README).tmpl $(BLUEVM_OPS_TBL)
 	./$< > $@

--- a/common.mk
+++ b/common.mk
@@ -15,3 +15,6 @@ DD = dd status=none bs=1024
 SED_TBL = sed -rn "s/^op[NB]I?\top_([^,]+), ([0-9]), [^\t]+\t;\t(.*)/\1\t\2\t\3/p"
 
 README = README.md
+
+SHIM = $(BASE_DIR)/shim.sh
+PROVE = prove -e $(SHIM) --ext bs0

--- a/shim.sh
+++ b/shim.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-./tools/bth/bin/bth < $1
+DIR="$( dirname -- "$( readlink -f -- "$0"; )"; )"
+
+"$DIR/tools/bth/bin/bth" < $1
 
 echo "1..1"
 echo "ok 1"

--- a/shim.sh
+++ b/shim.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./tools/bth/bin/bth < $1
+
+echo "1..1"
+echo "ok 1"

--- a/tools/bth/Makefile
+++ b/tools/bth/Makefile
@@ -16,9 +16,9 @@ TEST_OBJS = $(TESTS:test/%.bla=obj/test_%.bs0)
 
 GEN_FILES = $(BTH_INC) $(OP_TBLS) $(README)
 
-.PHONY: all clean
+.PHONY: all clean test
 
-all: $(BTH) $(GEN_FILES) $(TEST_OBJS)
+all: $(BTH) $(GEN_FILES) $(TEST_OBJS) test
 
 clean:
 	rm -rf bin obj $(GEN_FILES)
@@ -45,7 +45,10 @@ $(BTH): $(BLUEVM_NOEXT) $(OP_OBJS) obj/blk_5.bs0 | bin
 	cat $^ > $@ && chmod +x $@
 
 obj/test_%.bs0: test/%.bla $(BTH) | obj
-	$(BLASM) -n $< $@ && $(BTH) < $@
+	$(BLASM) -n $< $@
 
+test:
+	$(PROVE) obj/test_*
+	
 $(README): $(README).sh $(README).tmpl ops_low.tbl
 	./$< > $@


### PR DESCRIPTION
Adds a shim to fake `prove` into thinking test bs0 files are producing a TAP output. As the test harness gets TAP support this shim will be phased out. Also breaks out running tests from building the bs0 files.