### PR TITLE
Add setvar{b,w,d,q}

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,14 +172,12 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. setq, etc stack effects are backwards
-   1. see swap in op_setvarq, etc
-1. Add fasm2 dep in Makefile to git submodule init
-1. Add setvar{b,w,d,q} op that if op is used as var, sets its lit{b,w,d,q}
-   1. See setthr in bth ops_low.bla
-1. Use setvarq for here/sethere
-1. Use setvarq for ip/setip
 1. Expose argv/c via opcodes
+1. Add fasm2 dep in Makefile to git submodule init
+1. setq, etc stack effects feel backwards when not in test code
+   1. see swap in op_setvarq, etc
+1. Use setvarq for here/sethere?
+1. Use setvarq for ip/setip?
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end
 1. Grok more fasmg magic to improve blasm syntax

--- a/README.md
+++ b/README.md
@@ -109,43 +109,44 @@ Opcodes are subject to change.
 | 0x0C | setip | ( a -- ) | Set the location of the instruction pointer |
 | 0x0D | op | ( b -- a ) | Push addr of the offset into the op table for the opcode |
 | 0x0E | oph | ( -- a ) | Push addr of the opcode handler |
-| 0x0F | start | ( -- a ) | Push addr of the code buffer's start |
-| 0x10 | here | ( -- a ) | Push addr of the code buffer's here |
-| 0x11 | sethere | ( a -- ) | Set addr of the code buffer's here |
-| 0x12 | atincb | ( a -- b a' ) | Push byte value found at addr, increment and push addr |
-| 0x13 | atincw | ( a -- w a' ) | Push word value found at addr, increment and push addr |
-| 0x14 | atincd | ( a -- d a' ) | Push dword value found at addr, increment and push addr |
-| 0x15 | atincq | ( a -- q a' ) | Push qword value found at addr, increment and push addr |
-| 0x16 | atb | ( a -- b ) | Push byte value found at addr |
-| 0x17 | atw | ( a -- d ) | Push word value found at addr |
-| 0x18 | atd | ( a -- w ) | Push dword value found at addr |
-| 0x19 | atq | ( a -- q ) | Push qword value found at addr |
-| 0x1A | setincb | ( a b -- 'a ) | Write byte value to, increment and push addr |
-| 0x1B | setincw | ( a w -- 'a ) | Write word value to, increment and push addr |
-| 0x1C | setincd | ( a d -- 'a ) | Write dword value to, increment and push addr |
-| 0x1D | setincq | ( a q -- 'a ) | Write qword value to, increment and push addr |
-| 0x1E | setb | ( a b -- ) | Write byte value to addr |
-| 0x1F | setw | ( a w -- ) | Write word value to addr |
-| 0x20 | setd | ( a d -- ) | Write dword value to addr |
-| 0x21 | setq | ( a q -- ) | Write qword value to addr |
-| 0x22 | cb | ( b -- ) | Write byte value to and increment here |
-| 0x23 | cw | ( w -- ) | Write word value to and increment here |
-| 0x24 | cd | ( d -- ) | Write dword value to and increment here |
-| 0x25 | cq | ( q -- ) | Write qword value to and increment here |
-| 0x26 | litb | ( -- b ) | Push next byte from and increment instruction pointer |
-| 0x27 | litw | ( -- w ) | Push next word from and increment instruction pointer |
-| 0x28 | litd | ( -- d ) | Push next dword from and increment instruction pointer |
-| 0x29 | litq | ( -- q ) | Push next qword from and increment instruction pointer |
-| 0x2A | depth | ( -- n ) | Push depth of the data stack |
-| 0x2B | dup | ( x -- ) | Drops top of the data stack |
-| 0x2C | drop | ( a -- a a ) | Duplicate top of stack |
-| 0x2D | swap | ( a b -- b a ) | Swap top two values on the data stack |
-| 0x2E | not | ( x -- 'x ) | Bitwise not top of the data stack |
-| 0x2F | eq | ( a b -- t/f ) | Check top two items for equality and push result |
-| 0x30 | add | ( a b -- n ) | Push a + b |
-| 0x31 | sub | ( a b -- n ) | Push a - b |
-| 0x32 | shl | ( x n -- 'x ) | Push x shl n |
-| 0x33 | shr | ( x n -- 'x ) | Push x shr n |
+| 0x0F | setvarq | ( q b -- ) | Set litq value of var op |
+| 0x10 | start | ( -- a ) | Push addr of the code buffer's start |
+| 0x11 | here | ( -- a ) | Push addr of the code buffer's here |
+| 0x12 | sethere | ( a -- ) | Set addr of the code buffer's here |
+| 0x13 | atincb | ( a -- b a' ) | Push byte value found at addr, increment and push addr |
+| 0x14 | atincw | ( a -- w a' ) | Push word value found at addr, increment and push addr |
+| 0x15 | atincd | ( a -- d a' ) | Push dword value found at addr, increment and push addr |
+| 0x16 | atincq | ( a -- q a' ) | Push qword value found at addr, increment and push addr |
+| 0x17 | atb | ( a -- b ) | Push byte value found at addr |
+| 0x18 | atw | ( a -- d ) | Push word value found at addr |
+| 0x19 | atd | ( a -- w ) | Push dword value found at addr |
+| 0x1A | atq | ( a -- q ) | Push qword value found at addr |
+| 0x1B | setincb | ( a b -- 'a ) | Write byte value to, increment and push addr |
+| 0x1C | setincw | ( a w -- 'a ) | Write word value to, increment and push addr |
+| 0x1D | setincd | ( a d -- 'a ) | Write dword value to, increment and push addr |
+| 0x1E | setincq | ( a q -- 'a ) | Write qword value to, increment and push addr |
+| 0x1F | setb | ( a b -- ) | Write byte value to addr |
+| 0x20 | setw | ( a w -- ) | Write word value to addr |
+| 0x21 | setd | ( a d -- ) | Write dword value to addr |
+| 0x22 | setq | ( a q -- ) | Write qword value to addr |
+| 0x23 | cb | ( b -- ) | Write byte value to and increment here |
+| 0x24 | cw | ( w -- ) | Write word value to and increment here |
+| 0x25 | cd | ( d -- ) | Write dword value to and increment here |
+| 0x26 | cq | ( q -- ) | Write qword value to and increment here |
+| 0x27 | litb | ( -- b ) | Push next byte from and increment instruction pointer |
+| 0x28 | litw | ( -- w ) | Push next word from and increment instruction pointer |
+| 0x29 | litd | ( -- d ) | Push next dword from and increment instruction pointer |
+| 0x2A | litq | ( -- q ) | Push next qword from and increment instruction pointer |
+| 0x2B | depth | ( -- n ) | Push depth of the data stack |
+| 0x2C | dup | ( x -- ) | Drops top of the data stack |
+| 0x2D | drop | ( a -- a a ) | Duplicate top of stack |
+| 0x2E | swap | ( a b -- b a ) | Swap top two values on the data stack |
+| 0x2F | not | ( x -- 'x ) | Bitwise not top of the data stack |
+| 0x30 | eq | ( a b -- t/f ) | Check top two items for equality and push result |
+| 0x31 | add | ( a b -- n ) | Push a + b |
+| 0x32 | sub | ( a b -- n ) | Push a - b |
+| 0x33 | shl | ( x n -- 'x ) | Push x shl n |
+| 0x34 | shr | ( x n -- 'x ) | Push x shr n |
 
 ### Extended Low/High
 
@@ -168,9 +169,13 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
+1. setq, etc stack effects are backwards
+   1. see swap in op_setvarq, etc
 1. Add fasm2 dep in Makefile to git submodule init
 1. Add setvar{b,w,d,q} op that if op is used as var, sets its lit{b,w,d,q}
    1. See setthr in bth ops_low.bla
+1. Use setvarq for here/sethere
+1. Use setvarq for ip/setip
 1. Expose argv/c via opcodes
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end

--- a/README.md
+++ b/README.md
@@ -109,44 +109,47 @@ Opcodes are subject to change.
 | 0x0C | setip | ( a -- ) | Set the location of the instruction pointer |
 | 0x0D | op | ( b -- a ) | Push addr of the offset into the op table for the opcode |
 | 0x0E | oph | ( -- a ) | Push addr of the opcode handler |
-| 0x0F | setvarq | ( q b -- ) | Set litq value of var op |
-| 0x10 | start | ( -- a ) | Push addr of the code buffer's start |
-| 0x11 | here | ( -- a ) | Push addr of the code buffer's here |
-| 0x12 | sethere | ( a -- ) | Set addr of the code buffer's here |
-| 0x13 | atincb | ( a -- b a' ) | Push byte value found at addr, increment and push addr |
-| 0x14 | atincw | ( a -- w a' ) | Push word value found at addr, increment and push addr |
-| 0x15 | atincd | ( a -- d a' ) | Push dword value found at addr, increment and push addr |
-| 0x16 | atincq | ( a -- q a' ) | Push qword value found at addr, increment and push addr |
-| 0x17 | atb | ( a -- b ) | Push byte value found at addr |
-| 0x18 | atw | ( a -- d ) | Push word value found at addr |
-| 0x19 | atd | ( a -- w ) | Push dword value found at addr |
-| 0x1A | atq | ( a -- q ) | Push qword value found at addr |
-| 0x1B | setincb | ( a b -- 'a ) | Write byte value to, increment and push addr |
-| 0x1C | setincw | ( a w -- 'a ) | Write word value to, increment and push addr |
-| 0x1D | setincd | ( a d -- 'a ) | Write dword value to, increment and push addr |
-| 0x1E | setincq | ( a q -- 'a ) | Write qword value to, increment and push addr |
-| 0x1F | setb | ( a b -- ) | Write byte value to addr |
-| 0x20 | setw | ( a w -- ) | Write word value to addr |
-| 0x21 | setd | ( a d -- ) | Write dword value to addr |
-| 0x22 | setq | ( a q -- ) | Write qword value to addr |
-| 0x23 | cb | ( b -- ) | Write byte value to and increment here |
-| 0x24 | cw | ( w -- ) | Write word value to and increment here |
-| 0x25 | cd | ( d -- ) | Write dword value to and increment here |
-| 0x26 | cq | ( q -- ) | Write qword value to and increment here |
-| 0x27 | litb | ( -- b ) | Push next byte from and increment instruction pointer |
-| 0x28 | litw | ( -- w ) | Push next word from and increment instruction pointer |
-| 0x29 | litd | ( -- d ) | Push next dword from and increment instruction pointer |
-| 0x2A | litq | ( -- q ) | Push next qword from and increment instruction pointer |
-| 0x2B | depth | ( -- n ) | Push depth of the data stack |
-| 0x2C | dup | ( x -- ) | Drops top of the data stack |
-| 0x2D | drop | ( a -- a a ) | Duplicate top of stack |
-| 0x2E | swap | ( a b -- b a ) | Swap top two values on the data stack |
-| 0x2F | not | ( x -- 'x ) | Bitwise not top of the data stack |
-| 0x30 | eq | ( a b -- t/f ) | Check top two items for equality and push result |
-| 0x31 | add | ( a b -- n ) | Push a + b |
-| 0x32 | sub | ( a b -- n ) | Push a - b |
-| 0x33 | shl | ( x n -- 'x ) | Push x shl n |
-| 0x34 | shr | ( x n -- 'x ) | Push x shr n |
+| 0x0F | setvarb | ( b b -- ) | Set litb value of var op |
+| 0x10 | setvarw | ( w b -- ) | Set litw value of var op |
+| 0x11 | setvard | ( d b -- ) | Set litd value of var op |
+| 0x12 | setvarq | ( q b -- ) | Set litq value of var op |
+| 0x13 | start | ( -- a ) | Push addr of the code buffer's start |
+| 0x14 | here | ( -- a ) | Push addr of the code buffer's here |
+| 0x15 | sethere | ( a -- ) | Set addr of the code buffer's here |
+| 0x16 | atincb | ( a -- b a' ) | Push byte value found at addr, increment and push addr |
+| 0x17 | atincw | ( a -- w a' ) | Push word value found at addr, increment and push addr |
+| 0x18 | atincd | ( a -- d a' ) | Push dword value found at addr, increment and push addr |
+| 0x19 | atincq | ( a -- q a' ) | Push qword value found at addr, increment and push addr |
+| 0x1A | atb | ( a -- b ) | Push byte value found at addr |
+| 0x1B | atw | ( a -- d ) | Push word value found at addr |
+| 0x1C | atd | ( a -- w ) | Push dword value found at addr |
+| 0x1D | atq | ( a -- q ) | Push qword value found at addr |
+| 0x1E | setincb | ( a b -- 'a ) | Write byte value to, increment and push addr |
+| 0x1F | setincw | ( a w -- 'a ) | Write word value to, increment and push addr |
+| 0x20 | setincd | ( a d -- 'a ) | Write dword value to, increment and push addr |
+| 0x21 | setincq | ( a q -- 'a ) | Write qword value to, increment and push addr |
+| 0x22 | setb | ( a b -- ) | Write byte value to addr |
+| 0x23 | setw | ( a w -- ) | Write word value to addr |
+| 0x24 | setd | ( a d -- ) | Write dword value to addr |
+| 0x25 | setq | ( a q -- ) | Write qword value to addr |
+| 0x26 | cb | ( b -- ) | Write byte value to and increment here |
+| 0x27 | cw | ( w -- ) | Write word value to and increment here |
+| 0x28 | cd | ( d -- ) | Write dword value to and increment here |
+| 0x29 | cq | ( q -- ) | Write qword value to and increment here |
+| 0x2A | litb | ( -- b ) | Push next byte from and increment instruction pointer |
+| 0x2B | litw | ( -- w ) | Push next word from and increment instruction pointer |
+| 0x2C | litd | ( -- d ) | Push next dword from and increment instruction pointer |
+| 0x2D | litq | ( -- q ) | Push next qword from and increment instruction pointer |
+| 0x2E | depth | ( -- n ) | Push depth of the data stack |
+| 0x2F | dup | ( x -- ) | Drops top of the data stack |
+| 0x30 | drop | ( a -- a a ) | Duplicate top of stack |
+| 0x31 | swap | ( a b -- b a ) | Swap top two values on the data stack |
+| 0x32 | not | ( x -- 'x ) | Bitwise not top of the data stack |
+| 0x33 | eq | ( a b -- t/f ) | Check top two items for equality and push result |
+| 0x34 | add | ( a b -- n ) | Push a + b |
+| 0x35 | sub | ( a b -- n ) | Push a - b |
+| 0x36 | shl | ( x n -- 'x ) | Push x shl n |
+| 0x37 | shr | ( x n -- 'x ) | Push x shr n |
 
 ### Extended Low/High
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -115,14 +115,12 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. setq, etc stack effects are backwards
-   1. see swap in op_setvarq, etc
-1. Add fasm2 dep in Makefile to git submodule init
-1. Add setvar{b,w,d,q} op that if op is used as var, sets its lit{b,w,d,q}
-   1. See setthr in bth ops_low.bla
-1. Use setvarq for here/sethere
-1. Use setvarq for ip/setip
 1. Expose argv/c via opcodes
+1. Add fasm2 dep in Makefile to git submodule init
+1. setq, etc stack effects feel backwards when not in test code
+   1. see swap in op_setvarq, etc
+1. Use setvarq for here/sethere?
+1. Use setvarq for ip/setip?
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end
 1. Grok more fasmg magic to improve blasm syntax

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -115,9 +115,13 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
+1. setq, etc stack effects are backwards
+   1. see swap in op_setvarq, etc
 1. Add fasm2 dep in Makefile to git submodule init
 1. Add setvar{b,w,d,q} op that if op is used as var, sets its lit{b,w,d,q}
    1. See setthr in bth ops_low.bla
+1. Use setvarq for here/sethere
+1. Use setvarq for ip/setip
 1. Expose argv/c via opcodes
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end

--- a/lang/blasm/README.md
+++ b/lang/blasm/README.md
@@ -20,3 +20,4 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 ## TODOs
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
+1. Follow bluevm convention of `op_name_code` instead of `name.code`, see `op_setthr` in `bth`

--- a/lang/blasm/README.md.tmpl
+++ b/lang/blasm/README.md.tmpl
@@ -18,3 +18,4 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 ## TODOs
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
+1. Follow bluevm convention of `op_name_code` instead of `name.code`, see `op_setthr` in `bth`

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -16,6 +16,7 @@ iterate <opname, opsize>, \
 	setip, 1, \
 	op, 1, \
 	oph, 1, \
+	setvarq, 1, \
 	start, 1, \
 	here, 1, \
 	sethere, 1, \

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -16,6 +16,9 @@ iterate <opname, opsize>, \
 	setip, 1, \
 	op, 1, \
 	oph, 1, \
+	setvarb, 1, \
+	setvarw, 1, \
+	setvard, 1, \
 	setvarq, 1, \
 	start, 1, \
 	here, 1, \

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -80,6 +80,10 @@ opNI	op_oph, 1, 0	;	( -- a )	Push addr of the opcode handler
 	ret
 end_op
 
+opBI	op_setvarq, 1, 0	;	( q b -- )	Set litq value of var op
+	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setq_code, op_ret_code
+end_op
+
 opNI	op_start, 1, 0	;	( -- a )	Push addr of the code buffer's start
 	mov	rax, code_buffer
 	call	data_stack_push

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -80,6 +80,18 @@ opNI	op_oph, 1, 0	;	( -- a )	Push addr of the opcode handler
 	ret
 end_op
 
+opBI	op_setvarb, 1, 0	;	( b b -- )	Set litb value of var op
+	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setb_code, op_ret_code
+end_op
+
+opBI	op_setvarw, 1, 0	;	( w b -- )	Set litw value of var op
+	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setw_code, op_ret_code
+end_op
+
+opBI	op_setvard, 1, 0	;	( d b -- )	Set litd value of var op
+	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setd_code, op_ret_code
+end_op
+
 opBI	op_setvarq, 1, 0	;	( q b -- )	Set litq value of var op
 	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setq_code, op_ret_code
 end_op

--- a/ops_vm.tbl
+++ b/ops_vm.tbl
@@ -13,6 +13,7 @@ ip	1	( -- a )	Push location of the instruction pointer
 setip	1	( a -- )	Set the location of the instruction pointer
 op	1	( b -- a )	Push addr of the offset into the op table for the opcode
 oph	1	( -- a )	Push addr of the opcode handler
+setvarq	1	( q b -- )	Set litq value of var op
 start	1	( -- a )	Push addr of the code buffer's start
 here	1	( -- a )	Push addr of the code buffer's here
 sethere	1	( a -- )	Set addr of the code buffer's here

--- a/ops_vm.tbl
+++ b/ops_vm.tbl
@@ -13,6 +13,9 @@ ip	1	( -- a )	Push location of the instruction pointer
 setip	1	( a -- )	Set the location of the instruction pointer
 op	1	( b -- a )	Push addr of the offset into the op table for the opcode
 oph	1	( -- a )	Push addr of the opcode handler
+setvarb	1	( b b -- )	Set litb value of var op
+setvarw	1	( w b -- )	Set litw value of var op
+setvard	1	( d b -- )	Set litd value of var op
 setvarq	1	( q b -- )	Set litq value of var op
 start	1	( -- a )	Push addr of the code buffer's start
 here	1	( -- a )	Push addr of the code buffer's here

--- a/test/extoprt.bla
+++ b/test/extoprt.bla
@@ -3,7 +3,7 @@ include "../tools/bth/bth.inc"
 
 test
 
-litw	'01'
+litw	'02'
 plan
 
 ;
@@ -14,7 +14,7 @@ litb	0xFF
 op
 
 ; set flags and size
-litb	0x04
+litb	OPCODE_ENTRY_FLAG_BYTECODE
 setincb
 litb	0x01
 setincb
@@ -36,5 +36,34 @@ depth
 litb	0x00
 eq
 callop	0xFF
+
+;
+; implement extended opcode 0xFF to add 7 to the top of the stack
+;
+
+litb	0xFF
+op
+
+; set flags and size
+litb	OPCODE_ENTRY_FLAG_BYTECODE or OPCODE_ENTRY_FLAG_INLINED
+setincb
+litb	0x01
+setincb
+
+; compile bytecode into the opcode table
+litb	litb.code
+setincb
+litb	0x07
+setincb
+litb	add.code
+setincb
+litb	ret.code
+setb
+
+; call ext opcode to check initial value is 0
+litb	0x03
+callop	0xFF
+litb	0x0A
+okeq
 
 done

--- a/test/setvar.bla
+++ b/test/setvar.bla
@@ -1,0 +1,44 @@
+
+include "../tools/bth/bth.inc"
+
+test
+
+litw	'02'
+plan
+
+;
+; implement extended opcode 0xFF to be used as a varq
+;
+
+litb	0xFF
+op
+
+; set flags and size
+litb	OPCODE_ENTRY_FLAG_BYTECODE or OPCODE_ENTRY_FLAG_INLINED
+setincb
+litb	0x01
+setincb
+
+; compile bytecode into the opcode table
+litb	litq.code
+setincb
+litb	0x00
+setincq
+litb	ret.code
+setb
+
+; call ext opcode to check initial value is 0
+callop	0xFF
+ok0
+
+; set its value
+litq	0x1122334455667788
+dup
+litb	0xFF
+setvarq
+
+; call ext opcode to check updated value
+callop	0xFF
+okeq
+
+done

--- a/test/setvar.bla
+++ b/test/setvar.bla
@@ -3,8 +3,113 @@ include "../tools/bth/bth.inc"
 
 test
 
-litw	'02'
+litw	'08'
 plan
+
+;
+; implement extended opcode 0xFF to be used as a varb
+;
+
+litb	0xFF
+op
+
+; set flags and size
+litb	OPCODE_ENTRY_FLAG_BYTECODE or OPCODE_ENTRY_FLAG_INLINED
+setincb
+litb	0x01
+setincb
+
+; compile bytecode into the opcode table
+litb	litb.code
+setincb
+litb	0x00
+setincb
+litb	ret.code
+setb
+
+; call ext opcode to check initial value is 0
+callop	0xFF
+ok0
+
+; set its value
+litb	0x11
+dup
+litb	0xFF
+setvarb
+
+; call ext opcode to check updated value
+callop	0xFF
+okeq
+
+;
+; implement extended opcode 0xFF to be used as a varw
+;
+
+litb	0xFF
+op
+
+; set flags and size
+litb	OPCODE_ENTRY_FLAG_BYTECODE or OPCODE_ENTRY_FLAG_INLINED
+setincb
+litb	0x01
+setincb
+
+; compile bytecode into the opcode table
+litb	litw.code
+setincb
+litb	0x00
+setincw
+litb	ret.code
+setb
+
+; call ext opcode to check initial value is 0
+callop	0xFF
+ok0
+
+; set its value
+litw	0x1122
+dup
+litb	0xFF
+setvarw
+
+; call ext opcode to check updated value
+callop	0xFF
+okeq
+
+;
+; implement extended opcode 0xFF to be used as a vard
+;
+
+litb	0xFF
+op
+
+; set flags and size
+litb	OPCODE_ENTRY_FLAG_BYTECODE or OPCODE_ENTRY_FLAG_INLINED
+setincb
+litb	0x01
+setincb
+
+; compile bytecode into the opcode table
+litb	litd.code
+setincb
+litb	0x00
+setincd
+litb	ret.code
+setb
+
+; call ext opcode to check initial value is 0
+callop	0xFF
+ok0
+
+; set its value
+litd	0x11223344
+dup
+litb	0xFF
+setvard
+
+; call ext opcode to check updated value
+callop	0xFF
+okeq
 
 ;
 ; implement extended opcode 0xFF to be used as a varq

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -16,23 +16,22 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 |----|----|----|----|
 | 0x80 | tst | ( -- a ) | Push addr of TAP output's start |
 | 0x81 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x82 | thrM | ( -- a ) | Push addr of TAP output's here modification point |
-| 0x83 | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x84 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x85 | wokA | ( a -- ) | Write ok line to addr |
-| 0x86 | wprep | ( -- ) | Preps the write system call |
-| 0x87 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x88 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x89 | sysret | ( -- ) | System call and return for mccall |
-| 0x8A | test | ( w -- ) | Initialize a test suite |
-| 0x8B | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x8C | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x8D | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x8E | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x8F | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x90 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x91 | ok0 | ( n -- ) | Ok top of stack is 0 |
-| 0x92 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x82 | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x83 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x84 | wokA | ( a -- ) | Write ok line to addr |
+| 0x85 | wprep | ( -- ) | Preps the write system call |
+| 0x86 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x87 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x88 | sysret | ( -- ) | System call and return for mccall |
+| 0x89 | test | ( w -- ) | Initialize a test suite |
+| 0x8A | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x8B | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x8C | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x8D | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x8E | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x8F | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x90 | ok0 | ( n -- ) | Ok top of stack is 0 |
+| 0x91 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -3,7 +3,6 @@
 iterate <opname, opsize>, \
 	tst, 1, \
 	thr, 1, \
-	thrM, 1, \
 	setthr, 1, \
 	endl, 1, \
 	wokA, 1, \

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -14,18 +14,9 @@ opBI	op_thr, 1, 0	;	( -- a )	Push addr of TAP output's here
 	ret
 end_op
 
-opBI	op_thrM, 1, 0	;	( -- a )	Push addr of TAP output's here modification point
-	litb	op_thr_code
-	op
-	litb	0x03
-	add
-	ret
-end_op
-
 opBI	op_setthr, 1, 0	;	( a -- )	Set addr of TAP output's here
-	callop	op_thrM_code
-	swap
-	setq
+	litb	op_thr_code
+	callop	setvarq.code
 	ret
 end_op
 

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -15,7 +15,7 @@ opBI	op_thr, 1, 0	;	( -- a )	Push addr of TAP output's here
 end_op
 
 opBI	op_thrM, 1, 0	;	( -- a )	Push addr of TAP output's here modification point
-	litq	op_thr_code
+	litb	op_thr_code
 	op
 	litb	0x03
 	add

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,6 +1,5 @@
 tst	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here
-thrM	1	( -- a )	Push addr of TAP output's here modification point
 setthr	1	( a -- )	Set addr of TAP output's here
 endl	1	( a -- )	End line of output and set TAP output's here
 wokA	1	( a -- )	Write ok line to addr


### PR DESCRIPTION
When an inline bytecode opcode is used as a var, the `setvar` family of ops will set the inlined literal value. Next time the op is called the new value is returned. AKA self modifying code.