### PR TITLE
Make start and here a var, use setvarq in sethere

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Add fasm2 dep in Makefile to git submodule init
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, etc
-1. Use setvarq for ip/setip?
+1. Better name for `op_oph` since opcode handler has different meaning in the vm
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end
 1. Grok more fasmg magic to improve blasm syntax

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ Opcodes are subject to change.
 | 0x08 | ret | ( -- ) | Pops value from return stack and sets the instruction pointer |
 | 0x09 | comp | ( -- ) | Begin compiling bytecode |
 | 0x0A | endcomp | ( -- a ) | Append ret and end compilation, push addr where compilation started |
-| 0x0B | ip | ( -- a ) | Push location of the instruction pointer |
-| 0x0C | setip | ( a -- ) | Set the location of the instruction pointer |
-| 0x0D | op | ( b -- a ) | Push addr of the offset into the op table for the opcode |
-| 0x0E | oph | ( -- a ) | Push addr of the opcode handler |
-| 0x0F | setvarb | ( b b -- ) | Set litb value of var op |
-| 0x10 | setvarw | ( w b -- ) | Set litw value of var op |
-| 0x11 | setvard | ( d b -- ) | Set litd value of var op |
-| 0x12 | setvarq | ( q b -- ) | Set litq value of var op |
+| 0x0B | op | ( b -- a ) | Push addr of the offset into the op table for the opcode |
+| 0x0C | oph | ( -- a ) | Push addr of the opcode handler |
+| 0x0D | setvarb | ( b b -- ) | Set litb value of var op |
+| 0x0E | setvarw | ( w b -- ) | Set litw value of var op |
+| 0x0F | setvard | ( d b -- ) | Set litd value of var op |
+| 0x10 | setvarq | ( q b -- ) | Set litq value of var op |
+| 0x11 | ip | ( -- a ) | Push location of the instruction pointer |
+| 0x12 | setip | ( a -- ) | Set the location of the instruction pointer |
 | 0x13 | start | ( -- a ) | Push addr of the code buffer's start |
 | 0x14 | here | ( -- a ) | Push addr of the code buffer's here |
 | 0x15 | sethere | ( a -- ) | Set addr of the code buffer's here |

--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Add fasm2 dep in Makefile to git submodule init
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, etc
-1. Use setvarq for here/sethere?
 1. Use setvarq for ip/setip?
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -119,7 +119,7 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Add fasm2 dep in Makefile to git submodule init
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, etc
-1. Use setvarq for ip/setip?
+1. Better name for `op_oph` since opcode handler has different meaning in the vm
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end
 1. Grok more fasmg magic to improve blasm syntax

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -119,7 +119,6 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Add fasm2 dep in Makefile to git submodule init
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, etc
-1. Use setvarq for here/sethere?
 1. Use setvarq for ip/setip?
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -14,7 +14,6 @@ opcode_handler_invalid dq OPCODE_HANDLER_INVALID
 
 return_stack_here dq return_stack
 data_stack_here dq data_stack
-code_buffer_here dq code_buffer
 
 include "bluevm_defs.inc"
 include "stack.inc"

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -12,14 +12,14 @@ iterate <opname, opsize>, \
 	ret, 1, \
 	comp, 1, \
 	endcomp, 1, \
-	ip, 1, \
-	setip, 1, \
 	op, 1, \
 	oph, 1, \
 	setvarb, 1, \
 	setvarw, 1, \
 	setvard, 1, \
 	setvarq, 1, \
+	ip, 1, \
+	setip, 1, \
 	start, 1, \
 	here, 1, \
 	sethere, 1, \

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -57,20 +57,6 @@ end_op
 opN	op_comp, 1, OPCODE_ENTRY_FLAG_IMMEDIATE	;	( -- )	Begin compiling bytecode
 opN	op_endcomp, 1, OPCODE_ENTRY_FLAG_IMMEDIATE	;	( -- a )	Append ret and end compilation, push addr where compilation started
 
-opNI	op_ip, 1, 0	;	( -- a )	Push location of the instruction pointer
-	mov	rax, [instruction_pointer]
-	call	data_stack_push
-
-	ret
-end_op
-
-opNI	op_setip, 1, 0	;	( a -- )	Set the location of the instruction pointer
-	call	data_stack_pop
-	mov	[instruction_pointer], rax
-
-	ret
-end_op
-
 opN	op_op, 1, 0	;	( b -- a )	Push addr of the offset into the op table for the opcode
 
 opNI	op_oph, 1, 0	;	( -- a )	Push addr of the opcode handler
@@ -94,6 +80,20 @@ end_op
 
 opBI	op_setvarq, 1, 0	;	( q b -- )	Set litq value of var op
 	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setq_code, op_ret_code
+end_op
+
+opNI	op_ip, 1, 0	;	( -- a )	Push location of the instruction pointer
+	mov	rax, [instruction_pointer]
+	call	data_stack_push
+
+	ret
+end_op
+
+opNI	op_setip, 1, 0	;	( a -- )	Set the location of the instruction pointer
+	call	data_stack_pop
+	mov	[instruction_pointer], rax
+
+	ret
 end_op
 
 opBI	op_start, 1, 0	;	( -- a )	Push addr of the code buffer's start

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -96,25 +96,20 @@ opBI	op_setvarq, 1, 0	;	( q b -- )	Set litq value of var op
 	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setq_code, op_ret_code
 end_op
 
-opNI	op_start, 1, 0	;	( -- a )	Push addr of the code buffer's start
-	mov	rax, code_buffer
-	call	data_stack_push
-	
-	ret
+opBI	op_start, 1, 0	;	( -- a )	Push addr of the code buffer's start
+	db op_litq_code
+	dq code_buffer
+	db op_ret_code
 end_op
 	
-opNI	op_here, 1, 0	;	( -- a )	Push addr of the code buffer's here
-	mov	rax, [code_buffer_here]
-	call	data_stack_push
-
-	ret
+opBI	op_here, 1, 0	;	( -- a )	Push addr of the code buffer's here
+	db op_litq_code
+	code_buffer_here dq code_buffer
+	db op_ret_code
 end_op
 
-opNI	op_sethere, 1, 0	;	( a -- )	Set addr of the code buffer's here
-	call	data_stack_pop
-	mov	[code_buffer_here], rax
-
-	ret
+opBI	op_sethere, 1, 0	;	( a -- )	Set addr of the code buffer's here
+	db op_litb_code, op_here_code, op_setvarq_code, op_ret_code
 end_op
 
 opNI	op_atincb, 1, 0	;	( a -- b a' )	Push byte value found at addr, increment and push addr

--- a/ops_vm.tbl
+++ b/ops_vm.tbl
@@ -9,14 +9,14 @@ fromr	1	( -- a )	Move top of return stacl to data stack
 ret	1	( -- )	Pops value from return stack and sets the instruction pointer
 comp	1	( -- )	Begin compiling bytecode
 endcomp	1	( -- a )	Append ret and end compilation, push addr where compilation started
-ip	1	( -- a )	Push location of the instruction pointer
-setip	1	( a -- )	Set the location of the instruction pointer
 op	1	( b -- a )	Push addr of the offset into the op table for the opcode
 oph	1	( -- a )	Push addr of the opcode handler
 setvarb	1	( b b -- )	Set litb value of var op
 setvarw	1	( w b -- )	Set litw value of var op
 setvard	1	( d b -- )	Set litd value of var op
 setvarq	1	( q b -- )	Set litq value of var op
+ip	1	( -- a )	Push location of the instruction pointer
+setip	1	( a -- )	Set the location of the instruction pointer
 start	1	( -- a )	Push addr of the code buffer's start
 here	1	( -- a )	Push addr of the code buffer's here
 sethere	1	( a -- )	Set addr of the code buffer's here


### PR DESCRIPTION
Moved `start`, `here` and `sethere` to be inlined bytecode ops instead of native ops. Moved the `code_buffer_here` label to nest it in the `litq` so native code and bytecode read/mutate the same value. Also moved `ip` and `setip` down the opcode list to be with other vars.