### PR TITLE
Drop need for shim.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ Opcodes are subject to change.
 | 0x35 | eq | ( a b -- t/f ) | Check top two items for equality and push result |
 | 0x36 | add | ( a b -- n ) | Push a + b |
 | 0x37 | sub | ( a b -- n ) | Push a - b |
-| 0x38 | shl | ( x n -- 'x ) | Push x shl n |
-| 0x39 | shr | ( x n -- 'x ) | Push x shr n |
+| 0x38 | and | ( a b -- n ) | Push logical and of a and b |
+| 0x39 | or | ( a b -- n ) | Push logical inclusive or of a and b |
+| 0x3A | shl | ( x n -- 'x ) | Push x shl n |
+| 0x3B | shr | ( x n -- 'x ) | Push x shr n |
 
 ### Extended Low/High
 
@@ -176,7 +178,7 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 1. Rename `op_op` to `op_opent` or similar
 1. Remove if/ifnot, ip/setip
-1. Bug: Add an opcode to ops_vm that is kinda high up and `make` fails until `make clean`
+1. Bug: add/remove ops and `make` fails until `make clean`
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, op_cb, etc
 1. Consider here, some merging of `cb`, `setb`, `clitb`, etc

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -117,7 +117,7 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 1. Rename `op_op` to `op_opent` or similar
 1. Remove if/ifnot, ip/setip
-1. Bug: Add an opcode to ops_vm that is kinda high up and `make` fails until `make clean`
+1. Bug: add/remove ops and `make` fails until `make clean`
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, op_cb, etc
 1. Consider here, some merging of `cb`, `setb`, `clitb`, etc

--- a/common.mk
+++ b/common.mk
@@ -16,6 +16,4 @@ SED_TBL = sed -rn "s/^op[NB]I?\top_([^,]+), ([0-9]), [^\t]+\t;\t(.*)/\1\t\2\t\3/
 
 README = README.md
 
-#SHIM = $(BASE_DIR)/shim.sh
-#PROVE = prove -e $(SHIM) --ext bs0
 PROVE = prove -e $(BTH) --ext bs0

--- a/common.mk
+++ b/common.mk
@@ -16,5 +16,6 @@ SED_TBL = sed -rn "s/^op[NB]I?\top_([^,]+), ([0-9]), [^\t]+\t;\t(.*)/\1\t\2\t\3/
 
 README = README.md
 
-SHIM = $(BASE_DIR)/shim.sh
-PROVE = prove -e $(SHIM) --ext bs0
+#SHIM = $(BASE_DIR)/shim.sh
+#PROVE = prove -e $(SHIM) --ext bs0
+PROVE = prove -e $(BTH) --ext bs0

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -57,6 +57,8 @@ iterate <opname, opsize>, \
 	eq, 1, \
 	add, 1, \
 	sub, 1, \
+	and, 1, \
+	or, 1, \
 	shl, 1, \
 	shr, 1, \
 

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -312,6 +312,22 @@ opNI	op_sub, 1, 0	;	( a b -- n )	Push a - b
 	ret
 end_op
 
+opNI	op_and, 1, 0	;	( a b -- n )	Push logical and of a and b
+	call	data_stack_pop2a
+	and	rax, rcx
+	call	data_stack_push
+
+	ret
+end_op
+
+opNI	op_or, 1, 0	;	( a b -- n )	Push logical inclusive or of a and b
+	call	data_stack_pop2a
+	or	rax, rcx
+	call	data_stack_push
+
+	ret
+end_op
+
 opNI	op_shl, 1, 0	;	( x n -- 'x )	Push x shl n
 	call	data_stack_pop2a
 	shl	rax, cl

--- a/ops_vm.tbl
+++ b/ops_vm.tbl
@@ -54,5 +54,7 @@ not	1	( x -- 'x )	Bitwise not top of the data stack
 eq	1	( a b -- t/f )	Check top two items for equality and push result
 add	1	( a b -- n )	Push a + b
 sub	1	( a b -- n )	Push a - b
+and	1	( a b -- n )	Push logical and of a and b
+or	1	( a b -- n )	Push logical inclusive or of a and b
 shl	1	( x n -- 'x )	Push x shl n
 shr	1	( x n -- 'x )	Push x shr n

--- a/shim.sh
+++ b/shim.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-DIR="$( dirname -- "$( readlink -f -- "$0"; )"; )"
-
-echo "$DIR/tools/bth/bin/bth"
-"$DIR/tools/bth/bin/bth" < $1

--- a/test/args.bla
+++ b/test/args.bla
@@ -7,7 +7,7 @@ litw	'02'
 plan
 
 argc
-litb	0x01
+litb	0x02
 okeq
 
 argv

--- a/test/stack.bla
+++ b/test/stack.bla
@@ -3,7 +3,7 @@ include "../tools/bth/bth.inc"
 
 test
 
-litw	'11'
+litw	'13'
 plan
 
 ; stack has 0 depth at start
@@ -48,6 +48,20 @@ litb	0x07
 litb	0x02
 add
 litb	0x09
+okeq
+
+; and
+litb	0x01
+litb	0x02
+and
+litb	0x00
+okeq
+
+; or
+litb	0x01
+litb	0x02
+or
+litb	0x03
 okeq
 
 ; shl/shr

--- a/tools/bth/Makefile
+++ b/tools/bth/Makefile
@@ -38,10 +38,7 @@ $(BTH_INC): $(BTH_INC).sh $(BTH_INC).tmpl $(OP_TBLS)
 obj/%.bs0: %.bla $(BTH_INC) | obj
 	$(BLASM) -n $< $@
 
-obj/blk_%.bs0: $(BLUEVM) | obj
-	$(DD) if=$(BLUEVM) of=$@ skip=$* count=1
-	
-$(BTH): $(BLUEVM_NOEXT) $(OP_OBJS) obj/blk_5.bs0 | bin
+$(BTH): $(BLUEVM_NOEXT) $(OP_OBJS) obj/bth.bs0 | bin
 	cat $^ > $@ && chmod +x $@
 
 obj/test_%.bs0: test/%.bla $(BTH) | obj

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -30,17 +30,16 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x8D | wprep | ( -- ) | Preps the write system call |
 | 0x8E | wlen | ( -- ) | Buffer length for the write system call |
 | 0x8F | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x90 | sysret | ( -- ) | System call and return for mccall |
-| 0x91 | test | ( w -- ) | Initialize a test suite |
-| 0x92 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x93 | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x94 | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x95 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x96 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x97 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x98 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x99 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x9A | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x90 | test | ( w -- ) | Initialize a test suite |
+| 0x91 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x92 | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x93 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x94 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x95 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x96 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x97 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x98 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x99 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -15,24 +15,25 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
 | 0x80 | tst | ( -- a ) | Push addr of TAP output's start |
-| 0x81 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x82 | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x83 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x84 | woka | ( a -- ) | Write ok line to addr |
-| 0x85 | wprep | ( -- ) | Preps the write system call |
-| 0x86 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x87 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x88 | sysret | ( -- ) | System call and return for mccall |
-| 0x89 | test | ( w -- ) | Initialize a test suite |
-| 0x8A | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x8B | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x8C | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x8D | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x8E | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x8F | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x90 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x91 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x92 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x81 | tfd | ( -- d ) | Push fd of test input file |
+| 0x82 | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x83 | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x84 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x85 | woka | ( a -- ) | Write ok line to addr |
+| 0x86 | wprep | ( -- ) | Preps the write system call |
+| 0x87 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x88 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x89 | sysret | ( -- ) | System call and return for mccall |
+| 0x8A | test | ( w -- ) | Initialize a test suite |
+| 0x8B | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x8C | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x8D | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x8E | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x8F | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x90 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x91 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x92 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x93 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -15,28 +15,29 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
 | 0x80 | chkargc | ( -- ) | Exit with error unless argc is 2 |
-| 0x81 | cmovd | ( d b -- ) | Compile mov of dword into register b |
-| 0x82 | cmovq | ( q b -- ) | Compile mov of qword into register b |
-| 0x83 | tfd | ( -- d ) | Push fd of test input file |
-| 0x84 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x85 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x86 | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x87 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x88 | woka | ( a -- ) | Write ok line to addr |
-| 0x89 | wprep | ( -- ) | Preps the write system call |
-| 0x8A | wlen | ( -- ) | Buffer length for the write system call |
-| 0x8B | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x8C | sysret | ( -- ) | System call and return for mccall |
-| 0x8D | test | ( w -- ) | Initialize a test suite |
-| 0x8E | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x8F | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x90 | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x91 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x92 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x93 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x94 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x95 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x96 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x81 | cmovd | ( d b -- ) | Compile mov b, dword |
+| 0x82 | cmovq | ( q b -- ) | Compile mov b, qword |
+| 0x83 | cxord | ( b -- ) | Compile xor b, b |
+| 0x84 | tfd | ( -- d ) | Push fd of test input file |
+| 0x85 | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x86 | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x87 | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x88 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x89 | woka | ( a -- ) | Write ok line to addr |
+| 0x8A | wprep | ( -- ) | Preps the write system call |
+| 0x8B | wlen | ( -- ) | Buffer length for the write system call |
+| 0x8C | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x8D | sysret | ( -- ) | System call and return for mccall |
+| 0x8E | test | ( w -- ) | Initialize a test suite |
+| 0x8F | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x90 | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x91 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x92 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x93 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x94 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x95 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x96 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x97 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -21,25 +21,28 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x84 | cstosd | ( -- ) | Compile stosd |
 | 0x85 | csys | ( -- ) | Compile syscall |
 | 0x86 | cxord | ( b -- ) | Compile xor b, b |
-| 0x87 | tfd | ( -- d ) | Push fd of test input file |
-| 0x88 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x89 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x8A | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x8B | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x8C | woka | ( a -- ) | Write ok line to addr |
-| 0x8D | wprep | ( -- ) | Preps the write system call |
-| 0x8E | wlen | ( -- ) | Buffer length for the write system call |
-| 0x8F | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x90 | test | ( w -- ) | Initialize a test suite |
-| 0x91 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x92 | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x93 | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x94 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x95 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x96 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x97 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x98 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x99 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x87 | cdstarg | ( -- ) | Compile movabs rdi, _addr of argv[1]_ |
+| 0x88 | flgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY)_ |
+| 0x89 | scopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02)_ |
+| 0x8A | tfd | ( -- d ) | Push fd of test input file |
+| 0x8B | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x8C | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x8D | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x8E | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x8F | woka | ( a -- ) | Write ok line to addr |
+| 0x90 | wprep | ( -- ) | Preps the write system call |
+| 0x91 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x92 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x93 | test | ( w -- ) | Initialize a test suite |
+| 0x94 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x95 | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x96 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x97 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x98 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x99 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x9A | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x9B | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x9C | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 
@@ -47,3 +50,4 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 1. Split ops_low.bla into ops_pri.bla and ops_pub.bla
    1. Separate ops tables in README, etc
    1. Separate includes
+1. Redo wprep, wlen, waddr to use cxord, cmovd, etc

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -14,26 +14,27 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
-| 0x80 | tfd | ( -- d ) | Push fd of test input file |
-| 0x81 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x82 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x83 | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x84 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x85 | woka | ( a -- ) | Write ok line to addr |
-| 0x86 | wprep | ( -- ) | Preps the write system call |
-| 0x87 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x88 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x89 | sysret | ( -- ) | System call and return for mccall |
-| 0x8A | test | ( w -- ) | Initialize a test suite |
-| 0x8B | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x8C | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x8D | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x8E | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x8F | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x90 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x91 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x92 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x93 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x80 | chkargc | ( -- ) | Check that argc is 2 |
+| 0x81 | tfd | ( -- d ) | Push fd of test input file |
+| 0x82 | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x83 | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x84 | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x85 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x86 | woka | ( a -- ) | Write ok line to addr |
+| 0x87 | wprep | ( -- ) | Preps the write system call |
+| 0x88 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x89 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x8A | sysret | ( -- ) | System call and return for mccall |
+| 0x8B | test | ( w -- ) | Initialize a test suite |
+| 0x8C | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x8D | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x8E | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x8F | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x90 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x91 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x92 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x93 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x94 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -21,28 +21,29 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x84 | cstosd | ( -- ) | Compile stosd |
 | 0x85 | csys | ( -- ) | Compile syscall |
 | 0x86 | cxord | ( b -- ) | Compile xor b, b |
-| 0x87 | cdstarg | ( -- ) | Compile movabs rdi, _addr of argv[1]_ |
-| 0x88 | flgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY)_ |
-| 0x89 | scopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02)_ |
-| 0x8A | tfd | ( -- d ) | Push fd of test input file |
-| 0x8B | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x8C | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x8D | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x8E | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x8F | woka | ( a -- ) | Write ok line to addr |
-| 0x90 | wprep | ( -- ) | Preps the write system call |
-| 0x91 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x92 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x93 | test | ( w -- ) | Initialize a test suite |
-| 0x94 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x95 | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x96 | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x97 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x98 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x99 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x9A | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x9B | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x9C | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x87 | tfd | ( -- d ) | Push fd of test input file |
+| 0x88 | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x89 | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x8A | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x8B | cdstarg | ( -- ) | Compile movabs rdi, _addr of argv[1]_ |
+| 0x8C | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY)_ |
+| 0x8D | csopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02)_ |
+| 0x8E | dsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
+| 0x8F | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x90 | woka | ( a -- ) | Write ok line to addr |
+| 0x91 | wprep | ( -- ) | Preps the write system call |
+| 0x92 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x93 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x94 | test | ( w -- ) | Initialize a test suite |
+| 0x95 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x96 | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x97 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x98 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x99 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x9A | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x9B | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x9C | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x9D | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -29,21 +29,22 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x8C | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY)_ |
 | 0x8D | csopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02)_ |
 | 0x8E | dsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
-| 0x8F | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x90 | woka | ( a -- ) | Write ok line to addr |
-| 0x91 | wprep | ( -- ) | Preps the write system call |
-| 0x92 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x93 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x94 | test | ( w -- ) | Initialize a test suite |
-| 0x95 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x96 | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x97 | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x98 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x99 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x9A | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x9B | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x9C | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x9D | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x8F | opentfd | ( -- ) | Open argv[1] and set tfd |
+| 0x90 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x91 | woka | ( a -- ) | Write ok line to addr |
+| 0x92 | wprep | ( -- ) | Preps the write system call |
+| 0x93 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x94 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x95 | test | ( w -- ) | Initialize a test suite |
+| 0x96 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x97 | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x98 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x99 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x9A | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x9B | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x9C | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x9D | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x9E | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -27,27 +27,29 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x8A | setthr | ( a -- ) | Set addr of TAP output's here |
 | 0x8B | cdstarg | ( -- ) | Compile movabs rdi, _addr of argv[1]_ |
 | 0x8C | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY) |
-| 0x8D | csopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02) |
+| 0x8D | csopen | ( -- ) | Compile mov eax, 0x02 (sys_open); syscall |
 | 0x8E | cdsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
 | 0x8F | cfrmtfd | ( -- ) | Compile mov edi, _tfd_ |
 | 0x90 | csrctib | ( -- ) | Compile mov rsi, _addr of _test input block_ |
 | 0x91 | cblklen | ( -- ) | Compile mov edx, 0x0400 |
-| 0x92 | opentst | ( -- ) | Open argv[1] and set tfd |
-| 0x93 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x94 | woka | ( a -- ) | Write ok line to addr |
-| 0x95 | wprep | ( -- ) | Preps the write system call |
-| 0x96 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x97 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x98 | test | ( w -- ) | Initialize a test suite |
-| 0x99 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x9A | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x9B | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x9C | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x9D | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x9E | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x9F | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0xA0 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0xA1 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x92 | csread | ( -- ) | Compile xor eax, eax; syscall |
+| 0x93 | opentst | ( -- ) | Open argv[1] and set tfd |
+| 0x94 | readtst | ( -- ) | Read block from tfd into the test input block |
+| 0x95 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x96 | woka | ( a -- ) | Write ok line to addr |
+| 0x97 | wprep | ( -- ) | Preps the write system call |
+| 0x98 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x99 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x9A | test | ( w -- ) | Initialize a test suite |
+| 0x9B | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x9C | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x9D | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x9E | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x9F | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0xA0 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0xA1 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0xA2 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0xA3 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -35,21 +35,22 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x92 | csread | ( -- ) | Compile xor eax, eax; syscall |
 | 0x93 | opentst | ( -- ) | Open argv[1] and set tfd |
 | 0x94 | readtst | ( -- ) | Read block from tfd into the test input block |
-| 0x95 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x96 | woka | ( a -- ) | Write ok line to addr |
-| 0x97 | wprep | ( -- ) | Preps the write system call |
-| 0x98 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x99 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x9A | test | ( w -- ) | Initialize a test suite |
-| 0x9B | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x9C | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x9D | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x9E | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x9F | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0xA0 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0xA1 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0xA2 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0xA3 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x95 | runtst | ( -- ) | Run the test in the test input block |
+| 0x96 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x97 | woka | ( a -- ) | Write ok line to addr |
+| 0x98 | wprep | ( -- ) | Preps the write system call |
+| 0x99 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x9A | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x9B | test | ( w -- ) | Initialize a test suite |
+| 0x9C | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x9D | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x9E | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x9F | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0xA0 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0xA1 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0xA2 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0xA3 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0xA4 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -29,7 +29,7 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x8C | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY)_ |
 | 0x8D | csopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02)_ |
 | 0x8E | dsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
-| 0x8F | opentfd | ( -- ) | Open argv[1] and set tfd |
+| 0x8F | opentst | ( -- ) | Open argv[1] and set tfd |
 | 0x90 | endl | ( a -- ) | End line of output and set TAP output's here |
 | 0x91 | woka | ( a -- ) | Write ok line to addr |
 | 0x92 | wprep | ( -- ) | Preps the write system call |

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -17,27 +17,30 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x80 | chkargc | ( -- ) | Exit with error unless argc is 2 |
 | 0x81 | cmovd | ( d b -- ) | Compile mov b, dword |
 | 0x82 | cmovq | ( q b -- ) | Compile mov b, qword |
-| 0x83 | cxord | ( b -- ) | Compile xor b, b |
-| 0x84 | tfd | ( -- d ) | Push fd of test input file |
-| 0x85 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x86 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x87 | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x88 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x89 | woka | ( a -- ) | Write ok line to addr |
-| 0x8A | wprep | ( -- ) | Preps the write system call |
-| 0x8B | wlen | ( -- ) | Buffer length for the write system call |
-| 0x8C | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x8D | sysret | ( -- ) | System call and return for mccall |
-| 0x8E | test | ( w -- ) | Initialize a test suite |
-| 0x8F | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x90 | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x91 | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x92 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x93 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x94 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x95 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x96 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x97 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x83 | cret | ( -- ) | Compile ret |
+| 0x84 | cstosd | ( -- ) | Compile stosd |
+| 0x85 | csys | ( -- ) | Compile syscall |
+| 0x86 | cxord | ( b -- ) | Compile xor b, b |
+| 0x87 | tfd | ( -- d ) | Push fd of test input file |
+| 0x88 | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x89 | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x8A | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x8B | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x8C | woka | ( a -- ) | Write ok line to addr |
+| 0x8D | wprep | ( -- ) | Preps the write system call |
+| 0x8E | wlen | ( -- ) | Buffer length for the write system call |
+| 0x8F | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x90 | sysret | ( -- ) | System call and return for mccall |
+| 0x91 | test | ( w -- ) | Initialize a test suite |
+| 0x92 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x93 | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x94 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x95 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x96 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x97 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x98 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x99 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x9A | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -26,25 +26,28 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | 0x89 | thr | ( -- a ) | Push addr of TAP output's here |
 | 0x8A | setthr | ( a -- ) | Set addr of TAP output's here |
 | 0x8B | cdstarg | ( -- ) | Compile movabs rdi, _addr of argv[1]_ |
-| 0x8C | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY)_ |
-| 0x8D | csopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02)_ |
-| 0x8E | dsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
-| 0x8F | opentst | ( -- ) | Open argv[1] and set tfd |
-| 0x90 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x91 | woka | ( a -- ) | Write ok line to addr |
-| 0x92 | wprep | ( -- ) | Preps the write system call |
-| 0x93 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x94 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x95 | test | ( w -- ) | Initialize a test suite |
-| 0x96 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x97 | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x98 | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x99 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x9A | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x9B | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x9C | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x9D | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x9E | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x8C | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY) |
+| 0x8D | csopen | ( -- ) | Compile mov eax, SYS_OPEN (0x02) |
+| 0x8E | cdsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
+| 0x8F | cfrmtfd | ( -- ) | Compile mov edi, _tfd_ |
+| 0x90 | csrctib | ( -- ) | Compile mov rsi, _addr of _test input block_ |
+| 0x91 | cblklen | ( -- ) | Compile mov edx, 0x0400 |
+| 0x92 | opentst | ( -- ) | Open argv[1] and set tfd |
+| 0x93 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x94 | woka | ( a -- ) | Write ok line to addr |
+| 0x95 | wprep | ( -- ) | Preps the write system call |
+| 0x96 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x97 | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x98 | test | ( w -- ) | Initialize a test suite |
+| 0x99 | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x9A | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x9B | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x9C | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x9D | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x9E | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x9F | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0xA0 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0xA1 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -14,8 +14,8 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
-| 0x80 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x81 | tfd | ( -- d ) | Push fd of test input file |
+| 0x80 | tfd | ( -- d ) | Push fd of test input file |
+| 0x81 | oblk | ( -- a ) | Push addr of TAP output's start |
 | 0x82 | thr | ( -- a ) | Push addr of TAP output's here |
 | 0x83 | setthr | ( a -- ) | Set addr of TAP output's here |
 | 0x84 | endl | ( a -- ) | End line of output and set TAP output's here |

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -14,7 +14,7 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
-| 0x80 | tst | ( -- a ) | Push addr of TAP output's start |
+| 0x80 | oblk | ( -- a ) | Push addr of TAP output's start |
 | 0x81 | tfd | ( -- d ) | Push fd of test input file |
 | 0x82 | thr | ( -- a ) | Push addr of TAP output's here |
 | 0x83 | setthr | ( a -- ) | Set addr of TAP output's here |

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -37,5 +37,7 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 
 ## TODOs
 
-1. Output plan from `done` without need to call `plan`
 1. Print "TAP version 14" when testing begins
+1. Split ops_low.bla into ops_pri.bla and ops_pub.bla
+   1. Separate ops tables in README, etc
+   1. Separate includes

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -15,27 +15,28 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
 | 0x80 | chkargc | ( -- ) | Exit with error unless argc is 2 |
-| 0x81 | cmovq | ( q b -- ) | Compile mov of qword into register b |
-| 0x82 | tfd | ( -- d ) | Push fd of test input file |
-| 0x83 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x84 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x85 | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x86 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x87 | woka | ( a -- ) | Write ok line to addr |
-| 0x88 | wprep | ( -- ) | Preps the write system call |
-| 0x89 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x8A | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x8B | sysret | ( -- ) | System call and return for mccall |
-| 0x8C | test | ( w -- ) | Initialize a test suite |
-| 0x8D | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x8E | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x8F | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x90 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x91 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x92 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x93 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x94 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x95 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x81 | cmovd | ( d b -- ) | Compile mov of dword into register b |
+| 0x82 | cmovq | ( q b -- ) | Compile mov of qword into register b |
+| 0x83 | tfd | ( -- d ) | Push fd of test input file |
+| 0x84 | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x85 | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x86 | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x87 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x88 | woka | ( a -- ) | Write ok line to addr |
+| 0x89 | wprep | ( -- ) | Preps the write system call |
+| 0x8A | wlen | ( -- ) | Buffer length for the write system call |
+| 0x8B | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x8C | sysret | ( -- ) | System call and return for mccall |
+| 0x8D | test | ( w -- ) | Initialize a test suite |
+| 0x8E | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x8F | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x90 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x91 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x92 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x93 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x94 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x95 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x96 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -14,27 +14,28 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
-| 0x80 | chkargc | ( -- ) | Check that argc is 2 |
-| 0x81 | tfd | ( -- d ) | Push fd of test input file |
-| 0x82 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x83 | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x84 | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x85 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x86 | woka | ( a -- ) | Write ok line to addr |
-| 0x87 | wprep | ( -- ) | Preps the write system call |
-| 0x88 | wlen | ( -- ) | Buffer length for the write system call |
-| 0x89 | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x8A | sysret | ( -- ) | System call and return for mccall |
-| 0x8B | test | ( w -- ) | Initialize a test suite |
-| 0x8C | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x8D | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x8E | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0x8F | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0x90 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0x91 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0x92 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0x93 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0x94 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x80 | chkargc | ( -- ) | Exit with error unless argc is 2 |
+| 0x81 | cmovq | ( q b -- ) | Compile mov of qword into register b |
+| 0x82 | tfd | ( -- d ) | Push fd of test input file |
+| 0x83 | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x84 | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x85 | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x86 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x87 | woka | ( a -- ) | Write ok line to addr |
+| 0x88 | wprep | ( -- ) | Preps the write system call |
+| 0x89 | wlen | ( -- ) | Buffer length for the write system call |
+| 0x8A | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x8B | sysret | ( -- ) | System call and return for mccall |
+| 0x8C | test | ( w -- ) | Initialize a test suite |
+| 0x8D | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0x8E | ok | ( -- ) | Write ok line to TAP output's here |
+| 0x8F | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0x90 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0x91 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0x92 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0x93 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0x94 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0x95 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/README.md.tmpl
+++ b/tools/bth/README.md.tmpl
@@ -16,5 +16,7 @@ _OPCODE_TABLE_
 
 ## TODOs
 
-1. Output plan from `done` without need to call `plan`
 1. Print "TAP version 14" when testing begins
+1. Split ops_low.bla into ops_pri.bla and ops_pub.bla
+   1. Separate ops tables in README, etc
+   1. Separate includes

--- a/tools/bth/README.md.tmpl
+++ b/tools/bth/README.md.tmpl
@@ -20,3 +20,4 @@ _OPCODE_TABLE_
 1. Split ops_low.bla into ops_pri.bla and ops_pub.bla
    1. Separate ops tables in README, etc
    1. Separate includes
+1. Redo wprep, wlen, waddr to use cxord, cmovd, etc

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -36,10 +36,7 @@ litb	EAX
 cmovd
 
 ; syscall
-litb	0x0F
-cb
-litb	0x05
-cb
+csys
 
 ; movabs rdi, _addr of tfd's litd_
 litb	tfd.code
@@ -50,12 +47,10 @@ litb	RDI
 cmovq
 
 ; stosd
-litb	0xAB
-cb
+cstosd
 
 ; ret
-litb	0xC3
-cb
+cret
 
 mccall
 
@@ -85,14 +80,10 @@ litb	EAX
 cxord
 
 ; syscall
-litb	0x0F
-cb
-litb	0x05
-cb
+csys
 
 ; ret
-litb	0xC3
-cb
+cret
 
 mccall
 

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -5,14 +5,7 @@ TEST_INPUT_BLK = 0x09
 
 SYS_OPEN = 0x02
 
-argc
-litb	0x02
-eq
-comp
-	litb	0x01
-	exit
-endcomp
-ifnot
+chkargc
 
 ; compile machine code to open argv[1] into `tfd`
 here

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -90,13 +90,13 @@ cq
 ; mov edx, 0x0400
 litb	0xBA
 cb
-litw	0x0400
+litw	0x400
 cd
 
 ; xor eax, eax
 litb	0x31
 cb
-litb	0xC9
+litb	0xC0
 cb
 
 ; syscall

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -11,29 +11,9 @@ RDI = EDI
 CODE_BLK = 0x07
 TEST_INPUT_BLK = 0x09
 
-SYS_OPEN = 0x02
-
 chkargc
 
-; compile machine code to open argv[1] into `tfd`
-here
-
-cdstarg
-cflgsro
-csopen
-
-; syscall
-csys
-
-dsttfd
-
-; stosd
-cstosd
-
-; ret
-cret
-
-mccall
+opentfd
 
 ; TODO: check fd
 

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,5 +1,7 @@
 include "bth.inc"
 
+INPUT_BLK = 0x08
+
 SYS_OPEN = 0x02
 
 argc
@@ -64,6 +66,58 @@ litb	0xC3
 cb
 
 mccall
+
+; TODO: check fd
+
+; compile machine code to read block from `tfd` into block 10
+here
+
+; mov edi, _tfd_
+litb	0xBF
+cb
+tfd
+cd
+
+; mov rsi, _addr of _input block_
+litb	0x48
+cb
+litb	0xBE
+cb
+litb	INPUT_BLK
+blk
+cq
+
+; mov edx, 0x0400
+litb	0xBA
+cb
+litw	0x0400
+cw
+
+; xor eax, eax
+litb	0x31
+cb
+litb	0xC9
+cb
+
+; syscall
+litb	0x0F
+cb
+litb	0x05
+cb
+
+; ret
+litb	0xC3
+cb
+
+mccall
+
+litb	INPUT_BLK
+blk
+call
+
+litb	0xFF
+exit
+
 
 tfd
 exit

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -19,19 +19,13 @@ chkargc
 here
 
 cdstarg
-flgsro
-scopen
+cflgsro
+csopen
 
 ; syscall
 csys
 
-; movabs rdi, _addr of tfd's litd_
-litb	tfd.code
-op
-litb	0x03
-add
-litb	RDI
-cmovq
+dsttfd
 
 ; stosd
 cstosd

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,0 +1,70 @@
+include "bth.inc"
+
+SYS_OPEN = 0x02
+
+argc
+litb	0x02
+eq
+comp
+	litb	0x01
+	exit
+endcomp
+ifnot
+
+; compile machine code to open argv[1] into `tfd`
+here
+
+; movabs rdi, _addr of argv[1]_
+litb	0x48
+cb
+litb	0xBF
+cb
+argv
+litb	0x08
+add
+atq
+cq
+
+; xor esi, esi (flags = READ_ONLY)
+litb	0x31
+cb
+litb	0xF6
+cb
+
+; mov eax, SYS_OPEN
+litb	0xB8
+cb
+litb	SYS_OPEN
+cd
+
+; syscall
+litb	0x0F
+cb
+litb	0x05
+cb
+
+; movabs rdi, _addr of tfd's litd_
+litb	0x48
+cb
+litb	0xBF
+cb
+
+litb	tfd.code
+op
+litb	0x03
+add
+cq
+
+; stosd
+litb	0xAB
+cb
+
+; ret
+litb	0xC3
+cb
+
+mccall
+
+tfd
+exit
+

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -69,7 +69,7 @@ mccall
 
 ; TODO: check fd
 
-; compile machine code to read block from `tfd` into block 10
+; compile machine code to read block from `tfd` into _input block_
 here
 
 ; mov edi, _tfd_
@@ -91,7 +91,7 @@ cq
 litb	0xBA
 cb
 litw	0x0400
-cw
+cd
 
 ; xor eax, eax
 litb	0x31
@@ -117,8 +117,3 @@ call
 
 litb	0xFF
 exit
-
-
-tfd
-exit
-

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,5 +1,8 @@
 include "bth.inc"
 
+RSI = 0x06
+RDI = 0x07
+
 CODE_BLK = 0x07
 TEST_INPUT_BLK = 0x09
 
@@ -11,15 +14,22 @@ chkargc
 here
 
 ; movabs rdi, _addr of argv[1]_
-litb	0x48
-cb
-litb	0xBF
-cb
+;litb	0x48
+;cb
+;litb	0xBF
+;cb
+;argv
+;litb	0x08
+;add
+;atq
+;cq
+
 argv
 litb	0x08
 add
 atq
-cq
+litb	RDI
+cmovq
 
 ; xor esi, esi (flags = READ_ONLY)
 litb	0x31

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -27,10 +27,8 @@ litb	RDI
 cmovq
 
 ; xor esi, esi (flags = READ_ONLY)
-litb	0x31
-cb
-litb	0xF6
-cb
+litb	ESI
+cxord
 
 ; mov eax, SYS_OPEN
 litb	SYS_OPEN
@@ -83,10 +81,8 @@ litb	EDX
 cmovd
 
 ; xor eax, eax
-litb	0x31
-cb
-litb	0xC0
-cb
+litb	EAX
+cxord
 
 ; syscall
 litb	0x0F

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,7 +1,11 @@
 include "bth.inc"
 
-RSI = 0x06
-RDI = 0x07
+EAX = 0x00
+ESI = 0x06
+EDI = 0x07
+
+RSI = ESI
+RDI = EDI
 
 CODE_BLK = 0x07
 TEST_INPUT_BLK = 0x09
@@ -14,16 +18,6 @@ chkargc
 here
 
 ; movabs rdi, _addr of argv[1]_
-;litb	0x48
-;cb
-;litb	0xBF
-;cb
-;argv
-;litb	0x08
-;add
-;atq
-;cq
-
 argv
 litb	0x08
 add
@@ -50,16 +44,12 @@ litb	0x05
 cb
 
 ; movabs rdi, _addr of tfd's litd_
-litb	0x48
-cb
-litb	0xBF
-cb
-
 litb	tfd.code
 op
 litb	0x03
 add
-cq
+litb	RDI
+cmovq
 
 ; stosd
 litb	0xAB
@@ -83,13 +73,10 @@ tfd
 cd
 
 ; mov rsi, _addr of _input block_
-litb	0x48
-cb
-litb	0xBE
-cb
 litb	TEST_INPUT_BLK
 blk
-cq
+litb	RSI
+cmovq
 
 ; mov edx, 0x0400
 litb	0xBA

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,6 +1,8 @@
 include "bth.inc"
 
-INPUT_BLK = 0x08
+CODE_BLK = 0x07
+TEST_INPUT_BLK = 0x09
+TEST_OUTPUT_BLK = 0x0A
 
 SYS_OPEN = 0x02
 
@@ -83,7 +85,7 @@ litb	0x48
 cb
 litb	0xBE
 cb
-litb	INPUT_BLK
+litb	TEST_INPUT_BLK
 blk
 cq
 
@@ -111,9 +113,15 @@ cb
 
 mccall
 
-litb	INPUT_BLK
+litb	CODE_BLK
+blk
+litb	here.code
+setvarq
+
+litb	TEST_INPUT_BLK
 blk
 call
 
+; this should never run
 litb	0xFF
 exit

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,21 +1,10 @@
 include "bth.inc"
 
-CODE_BLK = 0x07
-TEST_INPUT_BLK = 0x09
-
 chkargc
 
 opentst
 readtst
-
-litb	CODE_BLK
-blk
-litb	here.code
-setvarq
-
-litb	TEST_INPUT_BLK
-blk
-call
+runtst
 
 ; this should never run
 litb	0xFF

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,39 +1,12 @@
 include "bth.inc"
 
-EAX = 0x00
-EDX = 0x02
-ESI = 0x06
-EDI = 0x07
-
-RSI = ESI
-RDI = EDI
-
 CODE_BLK = 0x07
 TEST_INPUT_BLK = 0x09
 
 chkargc
 
 opentst
-
-
-; compile machine code to read block from `tfd` into _input block_
-here
-
-cfrmtfd
-csrctib
-cblklen
-
-; xor eax, eax
-litb	EAX
-cxord
-
-; syscall
-csys
-
-; ret
-cret
-
-mccall
+readtst
 
 litb	CODE_BLK
 blk

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -13,7 +13,7 @@ TEST_INPUT_BLK = 0x09
 
 chkargc
 
-opentfd
+opentst
 
 ; TODO: check fd
 

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -2,7 +2,6 @@ include "bth.inc"
 
 CODE_BLK = 0x07
 TEST_INPUT_BLK = 0x09
-TEST_OUTPUT_BLK = 0x0A
 
 SYS_OPEN = 0x02
 

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -15,26 +15,13 @@ chkargc
 
 opentst
 
-; TODO: check fd
 
 ; compile machine code to read block from `tfd` into _input block_
 here
 
-; mov edi, _tfd
-tfd
-litb	EDI
-cmovd
-
-; mov rsi, _addr of _input block_
-litb	TEST_INPUT_BLK
-blk
-litb	RSI
-cmovq
-
-; mov edx, 0x0400
-litw	0x400
-litb	EDX
-cmovd
+cfrmtfd
+csrctib
+cblklen
 
 ; xor eax, eax
 litb	EAX

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -18,22 +18,9 @@ chkargc
 ; compile machine code to open argv[1] into `tfd`
 here
 
-; movabs rdi, _addr of argv[1]_
-argv
-litb	0x08
-add
-atq
-litb	RDI
-cmovq
-
-; xor esi, esi (flags = READ_ONLY)
-litb	ESI
-cxord
-
-; mov eax, SYS_OPEN
-litb	SYS_OPEN
-litb	EAX
-cmovd
+cdstarg
+flgsro
+scopen
 
 ; syscall
 csys

--- a/tools/bth/bth.bla
+++ b/tools/bth/bth.bla
@@ -1,6 +1,7 @@
 include "bth.inc"
 
 EAX = 0x00
+EDX = 0x02
 ESI = 0x06
 EDI = 0x07
 
@@ -32,10 +33,9 @@ litb	0xF6
 cb
 
 ; mov eax, SYS_OPEN
-litb	0xB8
-cb
 litb	SYS_OPEN
-cd
+litb	EAX
+cmovd
 
 ; syscall
 litb	0x0F
@@ -66,11 +66,10 @@ mccall
 ; compile machine code to read block from `tfd` into _input block_
 here
 
-; mov edi, _tfd_
-litb	0xBF
-cb
+; mov edi, _tfd
 tfd
-cd
+litb	EDI
+cmovd
 
 ; mov rsi, _addr of _input block_
 litb	TEST_INPUT_BLK
@@ -79,10 +78,9 @@ litb	RSI
 cmovq
 
 ; mov edx, 0x0400
-litb	0xBA
-cb
 litw	0x400
-cd
+litb	EDX
+cmovd
 
 ; xor eax, eax
 litb	0x31

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -19,7 +19,9 @@ iterate <opname, opsize>, \
 	cfrmtfd, 1, \
 	csrctib, 1, \
 	cblklen, 1, \
+	csread, 1, \
 	opentst, 1, \
+	readtst, 1, \
 	endl, 1, \
 	woka, 1, \
 	wprep, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -16,7 +16,7 @@ iterate <opname, opsize>, \
 	cflgsro, 1, \
 	csopen, 1, \
 	dsttfd, 1, \
-	opentfd, 1, \
+	opentst, 1, \
 	endl, 1, \
 	woka, 1, \
 	wprep, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -8,13 +8,14 @@ iterate <opname, opsize>, \
 	cstosd, 1, \
 	csys, 1, \
 	cxord, 1, \
-	cdstarg, 1, \
-	flgsro, 1, \
-	scopen, 1, \
 	tfd, 1, \
 	oblk, 1, \
 	thr, 1, \
 	setthr, 1, \
+	cdstarg, 1, \
+	cflgsro, 1, \
+	csopen, 1, \
+	dsttfd, 1, \
 	endl, 1, \
 	woka, 1, \
 	wprep, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -4,6 +4,7 @@ iterate <opname, opsize>, \
 	chkargc, 1, \
 	cmovd, 1, \
 	cmovq, 1, \
+	cxord, 1, \
 	tfd, 1, \
 	oblk, 1, \
 	thr, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -22,6 +22,7 @@ iterate <opname, opsize>, \
 	csread, 1, \
 	opentst, 1, \
 	readtst, 1, \
+	runtst, 1, \
 	endl, 1, \
 	woka, 1, \
 	wprep, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -17,7 +17,6 @@ iterate <opname, opsize>, \
 	wprep, 1, \
 	wlen, 1, \
 	waddr, 1, \
-	sysret, 1, \
 	test, 1, \
 	plan, 1, \
 	ok, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -1,6 +1,7 @@
 ; Generated from bth.inc.tmpl
 
 iterate <opname, opsize>, \
+	chkargc, 1, \
 	tfd, 1, \
 	oblk, 1, \
 	thr, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -4,6 +4,9 @@ iterate <opname, opsize>, \
 	chkargc, 1, \
 	cmovd, 1, \
 	cmovq, 1, \
+	cret, 1, \
+	cstosd, 1, \
+	csys, 1, \
 	cxord, 1, \
 	tfd, 1, \
 	oblk, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -8,6 +8,9 @@ iterate <opname, opsize>, \
 	cstosd, 1, \
 	csys, 1, \
 	cxord, 1, \
+	cdstarg, 1, \
+	flgsro, 1, \
+	scopen, 1, \
 	tfd, 1, \
 	oblk, 1, \
 	thr, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -2,6 +2,7 @@
 
 iterate <opname, opsize>, \
 	tst, 1, \
+	tfd, 1, \
 	thr, 1, \
 	setthr, 1, \
 	endl, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -15,7 +15,10 @@ iterate <opname, opsize>, \
 	cdstarg, 1, \
 	cflgsro, 1, \
 	csopen, 1, \
-	dsttfd, 1, \
+	cdsttfd, 1, \
+	cfrmtfd, 1, \
+	csrctib, 1, \
+	cblklen, 1, \
 	opentst, 1, \
 	endl, 1, \
 	woka, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -2,6 +2,7 @@
 
 iterate <opname, opsize>, \
 	chkargc, 1, \
+	cmovq, 1, \
 	tfd, 1, \
 	oblk, 1, \
 	thr, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -1,8 +1,8 @@
 ; Generated from bth.inc.tmpl
 
 iterate <opname, opsize>, \
-	oblk, 1, \
 	tfd, 1, \
+	oblk, 1, \
 	thr, 1, \
 	setthr, 1, \
 	endl, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -2,6 +2,7 @@
 
 iterate <opname, opsize>, \
 	chkargc, 1, \
+	cmovd, 1, \
 	cmovq, 1, \
 	tfd, 1, \
 	oblk, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -1,7 +1,7 @@
 ; Generated from bth.inc.tmpl
 
 iterate <opname, opsize>, \
-	tst, 1, \
+	oblk, 1, \
 	tfd, 1, \
 	thr, 1, \
 	setthr, 1, \

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -16,6 +16,7 @@ iterate <opname, opsize>, \
 	cflgsro, 1, \
 	csopen, 1, \
 	dsttfd, 1, \
+	opentfd, 1, \
 	endl, 1, \
 	woka, 1, \
 	wprep, 1, \

--- a/tools/bth/ops_high.bla
+++ b/tools/bth/ops_high.bla
@@ -1,2 +1,0 @@
-; high ops intentionally left blank
-; this space is used to as the TAP output buffer

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -131,6 +131,22 @@ opBI	op_dsttfd, 1, 0	;	( -- )	Compile movabs rdi, _addr of tfd's litd_
 	ret
 end_op
 
+opBI	op_opentfd, 1, 0	;	( -- )	Open argv[1] and set tfd
+	here
+	
+	callop	op_cdstarg_code
+	callop	op_cflgsro_code
+	callop	op_csopen_code
+	callop	op_csys_code
+
+	callop	op_dsttfd_code
+	callop	op_cstosd_code
+	callop	op_cret_code
+
+	mccall
+	ret
+end_op
+
 opBI	op_endl, 1, 0	;	( a -- )	End line of output and set TAP output's here
 	litb	0x0A
 	setincb

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -5,6 +5,18 @@ TEST_OUTPUT_BLK = 0x0A
 opcode_tbl:
 .offset = 0x80
 
+opBI	op_chkargc, 1, 0	;	( -- )	Check that argc is 2
+	argc
+	litb	0x02
+	eq
+	comp
+		litb	0x01
+		exit
+	endcomp
+	ifnot
+	ret
+end_op
+
 opBI	op_tfd, 1, 0	;	( -- d )	Push fd of test input file
 	litd	0x00
 	ret

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -17,6 +17,14 @@ opBI	op_chkargc, 1, 0	;	( -- )	Exit with error unless argc is 2
 	ret
 end_op
 
+opBI	op_cmovd, 1, 0	;	( d b -- )	Compile mov of dword into register b
+	litb	0xB8
+	or
+	cb
+	cd
+	ret
+end_op
+
 opBI	op_cmovq, 1, 0	;	( q b -- )	Compile mov of qword into register b
 	litb	0x48
 	cb

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -135,15 +135,7 @@ opBI	op_waddr, 1, 0	;	( -- )	Addr of the buffer for the write system call
 	ret
 end_op
 
-opBI	op_sysret, 1, 0	;	( -- )	System call and return for mccall
-	; syscall
-	litw	0x050F
-	cw
-	; ret
-	litb	0xC3
-	cb
-	ret
-end_op
+;;;
 
 opBI	op_test, 1, 0	;	( w -- )	Initialize a test suite
 	callop	op_oblk_code
@@ -221,7 +213,8 @@ opBI	op_done, 1, 0	;	( -- )	Writes TAP output to stdout and exits with depth as 
 	callop	op_wprep_code
 	callop	op_wlen_code
 	callop	op_waddr_code
-	callop	op_sysret_code
+	callop	op_csys_code
+	callop	op_cret_code
 	mccall
 	depth
 	exit

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -35,6 +35,24 @@ opBI	op_cmovq, 1, 0	;	( q b -- )	Compile mov b, qword
 	ret
 end_op
 
+opBI	op_cret, 1, 0	;	( -- )	Compile ret
+	litb	0xC3
+	cb
+	ret
+end_op
+
+opBI	op_cstosd, 1, 0	;	( -- )	Compile stosd
+	litb	0xAB
+	cb
+	ret
+end_op
+
+opBI	op_csys, 1, 0	;	( -- )	Compile syscall
+	litw	0x050F
+	cw
+	ret
+end_op
+
 opBI	op_cxord, 1, 0	;	( b -- )	Compile xor b, b
 	litb	0x31
 	cb

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -10,6 +10,7 @@ RDI = EDI
 
 SYS_OPEN = 0x02
 
+BLK_CODE = 0x07
 BLK_TEST_INPUT = 0x09
 BLK_TEST_OUTPUT = 0x0A
 
@@ -115,7 +116,7 @@ opBI	op_cflgsro, 1, 0	;	( -- )	Compile xor esi, esi (flags = READ_ONLY)
 	ret
 end_op
 
-opBI	op_csopen, 1, 0	;	( -- )	Compile mov eax, SYS_OPEN (0x02)
+opBI	op_csopen, 1, 0	;	( -- )	Compile mov eax, 0x02 (sys_open); syscall
 	litb	SYS_OPEN
 	litb	EAX
 	callop	op_cmovd_code
@@ -155,6 +156,13 @@ opBI	op_cblklen, 1, 0	;	( -- )	Compile mov edx, 0x0400
 	ret
 end_op
 
+opBI	op_csread, 1, 0	;	( -- )	Compile xor eax, eax; syscall
+	litb	EAX
+	callop	op_cxord_code
+	callop	op_csys_code
+	ret
+end_op
+
 opBI	op_opentst, 1, 0	;	( -- )	Open argv[1] and set tfd
 	here
 	
@@ -168,6 +176,19 @@ opBI	op_opentst, 1, 0	;	( -- )	Open argv[1] and set tfd
 
 	mccall
 	; TODO: check fd
+	ret
+end_op
+
+opBI	op_readtst, 1, 0	;	( -- )	Read block from tfd into the test input block
+	here
+
+	callop	op_cfrmtfd_code
+	callop	op_csrctib_code
+	callop	op_cblklen_code
+	callop	op_csread_code
+	callop	op_cret_code
+
+	mccall
 	ret
 end_op
 

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -17,7 +17,7 @@ opBI	op_chkargc, 1, 0	;	( -- )	Exit with error unless argc is 2
 	ret
 end_op
 
-opBI	op_cmovd, 1, 0	;	( d b -- )	Compile mov of dword into register b
+opBI	op_cmovd, 1, 0	;	( d b -- )	Compile mov b, dword
 	litb	0xB8
 	or
 	cb
@@ -25,13 +25,26 @@ opBI	op_cmovd, 1, 0	;	( d b -- )	Compile mov of dword into register b
 	ret
 end_op
 
-opBI	op_cmovq, 1, 0	;	( q b -- )	Compile mov of qword into register b
+opBI	op_cmovq, 1, 0	;	( q b -- )	Compile mov b, qword
 	litb	0x48
 	cb
 	litb	0xB8
 	or
 	cb
 	cq
+	ret
+end_op
+
+opBI	op_cxord, 1, 0	;	( b -- )	Compile xor b, b
+	litb	0x31
+	cb
+	dup
+	litb	0x03
+	shl
+	or
+	litb	0xC0
+	or
+	cb
 	ret
 end_op
 

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -1,10 +1,12 @@
 ; low ops used for testing and producing TAP output
 
+TEST_OUTPUT_BLK = 0x0A
+
 opcode_tbl:
 .offset = 0x80
 
-opBI	op_tst, 1, 0	;	( -- a )	Push addr of TAP output's start
-	litb	0x0A
+opBI	op_oblk, 1, 0	;	( -- a )	Push addr of TAP output's start
+	litb	TEST_OUTPUT_BLK
 	blk
 	ret
 end_op
@@ -57,7 +59,7 @@ opBI	op_wlen, 1, 0	;	( -- )	Buffer length for the write system call
 	litb	0xBA
 	cb
 	callop	op_thr_code
-	callop	op_tst_code
+	callop	op_oblk_code
 	sub
 	cd
 	ret
@@ -67,7 +69,7 @@ opBI	op_waddr, 1, 0	;	( -- )	Addr of the buffer for the write system call
 	; movabs rsi, _addr of string_
 	litw	0xBE48
 	cw
-	callop	op_tst_code
+	callop	op_oblk_code
 	cq
 	ret
 end_op
@@ -83,7 +85,7 @@ opBI	op_sysret, 1, 0	;	( -- )	System call and return for mccall
 end_op
 
 opBI	op_test, 1, 0	;	( w -- )	Initialize a test suite
-	callop	op_tst_code
+	callop	op_oblk_code
 	callop	op_setthr_code
 	ret
 end_op

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -192,6 +192,18 @@ opBI	op_readtst, 1, 0	;	( -- )	Read block from tfd into the test input block
 	ret
 end_op
 
+opBI	op_runtst, 1, 0	;	( -- )	Run the test in the test input block
+	litb	BLK_CODE
+	blk
+	litb	here.code
+	setvarq
+
+	litb	BLK_TEST_INPUT
+	blk
+	call
+	ret
+end_op
+
 opBI	op_endl, 1, 0	;	( a -- )	End line of output and set TAP output's here
 	litb	0x0A
 	setincb

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -10,7 +10,8 @@ RDI = EDI
 
 SYS_OPEN = 0x02
 
-TEST_OUTPUT_BLK = 0x0A
+BLK_TEST_INPUT = 0x09
+BLK_TEST_OUTPUT = 0x0A
 
 opcode_tbl:
 .offset = 0x80
@@ -82,7 +83,7 @@ opBI	op_tfd, 1, 0	;	( -- d )	Push fd of test input file
 end_op
 
 opBI	op_oblk, 1, 0	;	( -- a )	Push addr of TAP output's start
-	litb	TEST_OUTPUT_BLK
+	litb	BLK_TEST_OUTPUT
 	blk
 	ret
 end_op
@@ -108,20 +109,21 @@ opBI	op_cdstarg, 1, 0	;	( -- )	Compile movabs rdi, _addr of argv[1]_
 	ret
 end_op
 
-opBI	op_cflgsro, 1, 0	;	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
+opBI	op_cflgsro, 1, 0	;	( -- )	Compile xor esi, esi (flags = READ_ONLY)
 	litb	ESI
 	callop	op_cxord_code
 	ret
 end_op
 
-opBI	op_csopen, 1, 0	;	( -- )	Compile mov eax, SYS_OPEN (0x02)_
+opBI	op_csopen, 1, 0	;	( -- )	Compile mov eax, SYS_OPEN (0x02)
 	litb	SYS_OPEN
 	litb	EAX
 	callop	op_cmovd_code
+	callop	op_csys_code
 	ret
 end_op
 
-opBI	op_dsttfd, 1, 0	;	( -- )	Compile movabs rdi, _addr of tfd's litd_
+opBI	op_cdsttfd, 1, 0	;	( -- )	Compile movabs rdi, _addr of tfd's litd_
 	litb	op_tfd_code
 	op
 	litb	0x03
@@ -131,19 +133,41 @@ opBI	op_dsttfd, 1, 0	;	( -- )	Compile movabs rdi, _addr of tfd's litd_
 	ret
 end_op
 
+opBI	op_cfrmtfd, 1, 0	;	( -- )	Compile mov edi, _tfd_
+	callop	op_tfd_code
+	litb	EDI
+	callop	op_cmovd_code
+	ret
+end_op
+
+opBI	op_csrctib, 1, 0	;	( -- )	Compile mov rsi, _addr of _test input block_
+	litb	BLK_TEST_INPUT
+	blk
+	litb	RSI
+	callop	op_cmovq_code
+	ret
+end_op
+
+opBI	op_cblklen, 1, 0	;	( -- )	Compile mov edx, 0x0400
+	litw	0x400
+	litb	EDX
+	callop	op_cmovd_code
+	ret
+end_op
+
 opBI	op_opentst, 1, 0	;	( -- )	Open argv[1] and set tfd
 	here
 	
 	callop	op_cdstarg_code
 	callop	op_cflgsro_code
 	callop	op_csopen_code
-	callop	op_csys_code
 
-	callop	op_dsttfd_code
+	callop	op_cdsttfd_code
 	callop	op_cstosd_code
 	callop	op_cret_code
 
 	mccall
+	; TODO: check fd
 	ret
 end_op
 

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -5,7 +5,7 @@ TEST_OUTPUT_BLK = 0x0A
 opcode_tbl:
 .offset = 0x80
 
-opBI	op_chkargc, 1, 0	;	( -- )	Check that argc is 2
+opBI	op_chkargc, 1, 0	;	( -- )	Exit with error unless argc is 2
 	argc
 	litb	0x02
 	eq
@@ -14,6 +14,16 @@ opBI	op_chkargc, 1, 0	;	( -- )	Check that argc is 2
 		exit
 	endcomp
 	ifnot
+	ret
+end_op
+
+opBI	op_cmovq, 1, 0	;	( q b -- )	Compile mov of qword into register b
+	litb	0x48
+	cb
+	litb	0xB8
+	or
+	cb
+	cq
 	ret
 end_op
 

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -9,6 +9,11 @@ opBI	op_tst, 1, 0	;	( -- a )	Push addr of TAP output's start
 	ret
 end_op
 
+opBI	op_tfd, 1, 0	;	( -- d )	Push fd of test input file
+	litd	0x00
+	ret
+end_op
+
 opBI	op_thr, 1, 0	;	( -- a )	Push addr of TAP output's here
 	litq	0x00
 	ret

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -5,14 +5,14 @@ TEST_OUTPUT_BLK = 0x0A
 opcode_tbl:
 .offset = 0x80
 
-opBI	op_oblk, 1, 0	;	( -- a )	Push addr of TAP output's start
-	litb	TEST_OUTPUT_BLK
-	blk
+opBI	op_tfd, 1, 0	;	( -- d )	Push fd of test input file
+	litd	0x00
 	ret
 end_op
 
-opBI	op_tfd, 1, 0	;	( -- d )	Push fd of test input file
-	litd	0x00
+opBI	op_oblk, 1, 0	;	( -- a )	Push addr of TAP output's start
+	litb	TEST_OUTPUT_BLK
+	blk
 	ret
 end_op
 

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -4,8 +4,8 @@ opcode_tbl:
 .offset = 0x80
 
 opBI	op_tst, 1, 0	;	( -- a )	Push addr of TAP output's start
-	litb	0xC0
-	op
+	litb	0x0A
+	blk
 	ret
 end_op
 

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -131,7 +131,7 @@ opBI	op_dsttfd, 1, 0	;	( -- )	Compile movabs rdi, _addr of tfd's litd_
 	ret
 end_op
 
-opBI	op_opentfd, 1, 0	;	( -- )	Open argv[1] and set tfd
+opBI	op_opentst, 1, 0	;	( -- )	Open argv[1] and set tfd
 	here
 	
 	callop	op_cdstarg_code

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -1,5 +1,15 @@
 ; low ops used for testing and producing TAP output
 
+EAX = 0x00
+EDX = 0x02
+ESI = 0x06
+EDI = 0x07
+
+RSI = ESI
+RDI = EDI
+
+SYS_OPEN = 0x02
+
 TEST_OUTPUT_BLK = 0x0A
 
 opcode_tbl:
@@ -66,6 +76,29 @@ opBI	op_cxord, 1, 0	;	( b -- )	Compile xor b, b
 	ret
 end_op
 
+opBI	op_cdstarg, 1, 0	;	( -- )	Compile movabs rdi, _addr of argv[1]_
+	argv
+	litb	0x08
+	add
+	atq
+	litb	RDI
+	callop	op_cmovq_code
+	ret
+end_op
+
+opBI	op_flgsro, 1, 0	;	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
+	litb	ESI
+	callop	op_cxord_code
+	ret
+end_op
+
+opBI	op_scopen, 1, 0	;	( -- )	Compile mov eax, SYS_OPEN (0x02)_
+	litb	SYS_OPEN
+	litb	EAX
+	callop	op_cmovd_code
+	ret
+end_op
+
 opBI	op_tfd, 1, 0	;	( -- d )	Push fd of test input file
 	litd	0x00
 	ret
@@ -89,7 +122,7 @@ opBI	op_setthr, 1, 0	;	( a -- )	Set addr of TAP output's here
 end_op
 
 opBI	op_endl, 1, 0	;	( a -- )	End line of output and set TAP output's here
-	litb	10
+	litb	0x0A
 	setincb
 	callop	op_setthr_code
 	ret

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -76,29 +76,6 @@ opBI	op_cxord, 1, 0	;	( b -- )	Compile xor b, b
 	ret
 end_op
 
-opBI	op_cdstarg, 1, 0	;	( -- )	Compile movabs rdi, _addr of argv[1]_
-	argv
-	litb	0x08
-	add
-	atq
-	litb	RDI
-	callop	op_cmovq_code
-	ret
-end_op
-
-opBI	op_flgsro, 1, 0	;	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
-	litb	ESI
-	callop	op_cxord_code
-	ret
-end_op
-
-opBI	op_scopen, 1, 0	;	( -- )	Compile mov eax, SYS_OPEN (0x02)_
-	litb	SYS_OPEN
-	litb	EAX
-	callop	op_cmovd_code
-	ret
-end_op
-
 opBI	op_tfd, 1, 0	;	( -- d )	Push fd of test input file
 	litd	0x00
 	ret
@@ -118,6 +95,39 @@ end_op
 opBI	op_setthr, 1, 0	;	( a -- )	Set addr of TAP output's here
 	litb	op_thr_code
 	setvarq
+	ret
+end_op
+
+opBI	op_cdstarg, 1, 0	;	( -- )	Compile movabs rdi, _addr of argv[1]_
+	argv
+	litb	0x08
+	add
+	atq
+	litb	RDI
+	callop	op_cmovq_code
+	ret
+end_op
+
+opBI	op_cflgsro, 1, 0	;	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
+	litb	ESI
+	callop	op_cxord_code
+	ret
+end_op
+
+opBI	op_csopen, 1, 0	;	( -- )	Compile mov eax, SYS_OPEN (0x02)_
+	litb	SYS_OPEN
+	litb	EAX
+	callop	op_cmovd_code
+	ret
+end_op
+
+opBI	op_dsttfd, 1, 0	;	( -- )	Compile movabs rdi, _addr of tfd's litd_
+	litb	op_tfd_code
+	op
+	litb	0x03
+	add
+	litb	RDI
+	callop	op_cmovq_code
 	ret
 end_op
 

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -5,13 +5,14 @@ cret	1	( -- )	Compile ret
 cstosd	1	( -- )	Compile stosd
 csys	1	( -- )	Compile syscall
 cxord	1	( b -- )	Compile xor b, b
-cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
-flgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
-scopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)_
 tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here
 setthr	1	( a -- )	Set addr of TAP output's here
+cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
+cflgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
+csopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)_
+dsttfd	1	( -- )	Compile movabs rdi, _addr of tfd's litd_
 endl	1	( a -- )	End line of output and set TAP output's here
 woka	1	( a -- )	Write ok line to addr
 wprep	1	( -- )	Preps the write system call

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -13,6 +13,7 @@ cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
 cflgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
 csopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)_
 dsttfd	1	( -- )	Compile movabs rdi, _addr of tfd's litd_
+opentfd	1	( -- )	Open argv[1] and set tfd
 endl	1	( a -- )	End line of output and set TAP output's here
 woka	1	( a -- )	Write ok line to addr
 wprep	1	( -- )	Preps the write system call

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -5,6 +5,9 @@ cret	1	( -- )	Compile ret
 cstosd	1	( -- )	Compile stosd
 csys	1	( -- )	Compile syscall
 cxord	1	( b -- )	Compile xor b, b
+cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
+flgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
+scopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)_
 tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,4 +1,5 @@
-chkargc	1	( -- )	Check that argc is 2
+chkargc	1	( -- )	Exit with error unless argc is 2
+cmovq	1	( q b -- )	Compile mov of qword into register b
 tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,6 +1,7 @@
 chkargc	1	( -- )	Exit with error unless argc is 2
-cmovd	1	( d b -- )	Compile mov of dword into register b
-cmovq	1	( q b -- )	Compile mov of qword into register b
+cmovd	1	( d b -- )	Compile mov b, dword
+cmovq	1	( q b -- )	Compile mov b, qword
+cxord	1	( b -- )	Compile xor b, b
 tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,4 +1,4 @@
-tst	1	( -- a )	Push addr of TAP output's start
+oblk	1	( -- a )	Push addr of TAP output's start
 tfd	1	( -- d )	Push fd of test input file
 thr	1	( -- a )	Push addr of TAP output's here
 setthr	1	( a -- )	Set addr of TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -19,6 +19,7 @@ cblklen	1	( -- )	Compile mov edx, 0x0400
 csread	1	( -- )	Compile xor eax, eax; syscall
 opentst	1	( -- )	Open argv[1] and set tfd
 readtst	1	( -- )	Read block from tfd into the test input block
+runtst	1	( -- )	Run the test in the test input block
 endl	1	( a -- )	End line of output and set TAP output's here
 woka	1	( a -- )	Write ok line to addr
 wprep	1	( -- )	Preps the write system call

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,5 +1,5 @@
-oblk	1	( -- a )	Push addr of TAP output's start
 tfd	1	( -- d )	Push fd of test input file
+oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here
 setthr	1	( a -- )	Set addr of TAP output's here
 endl	1	( a -- )	End line of output and set TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,4 +1,5 @@
 chkargc	1	( -- )	Exit with error unless argc is 2
+cmovd	1	( d b -- )	Compile mov of dword into register b
 cmovq	1	( q b -- )	Compile mov of qword into register b
 tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -13,7 +13,7 @@ cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
 cflgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
 csopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)_
 dsttfd	1	( -- )	Compile movabs rdi, _addr of tfd's litd_
-opentfd	1	( -- )	Open argv[1] and set tfd
+opentst	1	( -- )	Open argv[1] and set tfd
 endl	1	( a -- )	End line of output and set TAP output's here
 woka	1	( a -- )	Write ok line to addr
 wprep	1	( -- )	Preps the write system call

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -10,9 +10,12 @@ oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here
 setthr	1	( a -- )	Set addr of TAP output's here
 cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
-cflgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)_
-csopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)_
-dsttfd	1	( -- )	Compile movabs rdi, _addr of tfd's litd_
+cflgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)
+csopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)
+cdsttfd	1	( -- )	Compile movabs rdi, _addr of tfd's litd_
+cfrmtfd	1	( -- )	Compile mov edi, _tfd_
+csrctib	1	( -- )	Compile mov rsi, _addr of _test input block_
+cblklen	1	( -- )	Compile mov edx, 0x0400
 opentst	1	( -- )	Open argv[1] and set tfd
 endl	1	( a -- )	End line of output and set TAP output's here
 woka	1	( a -- )	Write ok line to addr

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -14,7 +14,6 @@ woka	1	( a -- )	Write ok line to addr
 wprep	1	( -- )	Preps the write system call
 wlen	1	( -- )	Buffer length for the write system call
 waddr	1	( -- )	Addr of the buffer for the write system call
-sysret	1	( -- )	System call and return for mccall
 test	1	( w -- )	Initialize a test suite
 plan	1	( w -- )	Plan w tests where w is two ascii characters such as '03'
 ok	1	( -- )	Write ok line to TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,6 +1,9 @@
 chkargc	1	( -- )	Exit with error unless argc is 2
 cmovd	1	( d b -- )	Compile mov b, dword
 cmovq	1	( q b -- )	Compile mov b, qword
+cret	1	( -- )	Compile ret
+cstosd	1	( -- )	Compile stosd
+csys	1	( -- )	Compile syscall
 cxord	1	( b -- )	Compile xor b, b
 tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,3 +1,4 @@
+chkargc	1	( -- )	Check that argc is 2
 tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,4 +1,5 @@
 tst	1	( -- a )	Push addr of TAP output's start
+tfd	1	( -- d )	Push fd of test input file
 thr	1	( -- a )	Push addr of TAP output's here
 setthr	1	( a -- )	Set addr of TAP output's here
 endl	1	( a -- )	End line of output and set TAP output's here

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -11,12 +11,14 @@ thr	1	( -- a )	Push addr of TAP output's here
 setthr	1	( a -- )	Set addr of TAP output's here
 cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
 cflgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)
-csopen	1	( -- )	Compile mov eax, SYS_OPEN (0x02)
+csopen	1	( -- )	Compile mov eax, 0x02 (sys_open); syscall
 cdsttfd	1	( -- )	Compile movabs rdi, _addr of tfd's litd_
 cfrmtfd	1	( -- )	Compile mov edi, _tfd_
 csrctib	1	( -- )	Compile mov rsi, _addr of _test input block_
 cblklen	1	( -- )	Compile mov edx, 0x0400
+csread	1	( -- )	Compile xor eax, eax; syscall
 opentst	1	( -- )	Open argv[1] and set tfd
+readtst	1	( -- )	Read block from tfd into the test input block
 endl	1	( a -- )	End line of output and set TAP output's here
 woka	1	( a -- )	Write ok line to addr
 wprep	1	( -- )	Preps the write system call


### PR DESCRIPTION
`bth` now runs a test file specified in `argv[1]` instead of from stdin. This obsoletes `shim.sh`.