### PR TITLE
Blasm updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,5 +182,4 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end
 1. Grok more fasmg magic to improve blasm syntax
-1. Add opcodes for `clitb`, etc
 1. Print error messages to disambiguate exit status

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -123,5 +123,4 @@ Along with the code for BlueVM this repository also contains some tools and exam
 1. Bring back a simpiler version of the `blue` language
 1. See about re-arranging >r order in op_compile_begin to simplify it and op_compile_end
 1. Grok more fasmg magic to improve blasm syntax
-1. Add opcodes for `clitb`, etc
 1. Print error messages to disambiguate exit status

--- a/lang/blasm/README.md
+++ b/lang/blasm/README.md
@@ -21,3 +21,4 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
 1. Look at `opBI` etc label generation doing what blasm.inc does, so local ops don't need `litop op_XXX_code`
+1. Convert clit* macros to calminstructions

--- a/lang/blasm/README.md
+++ b/lang/blasm/README.md
@@ -21,4 +21,3 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
 1. Follow bluevm convention of `op_name_code` instead of `name.code`, see `op_setthr` in `bth`
-1. Rename `callop` to something like `opnum` or `litop`

--- a/lang/blasm/README.md
+++ b/lang/blasm/README.md
@@ -20,3 +20,4 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 ## TODOs
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
+1. Look at `opBI` etc label generation doing what blasm.inc does, so local ops don't need `litop op_XXX_code`

--- a/lang/blasm/README.md
+++ b/lang/blasm/README.md
@@ -20,4 +20,3 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 ## TODOs
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
-1. Follow bluevm convention of `op_name_code` instead of `name.code`, see `op_setthr` in `bth`

--- a/lang/blasm/README.md.tmpl
+++ b/lang/blasm/README.md.tmpl
@@ -19,3 +19,4 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
 1. Look at `opBI` etc label generation doing what blasm.inc does, so local ops don't need `litop op_XXX_code`
+1. Convert clit* macros to calminstructions

--- a/lang/blasm/README.md.tmpl
+++ b/lang/blasm/README.md.tmpl
@@ -18,3 +18,4 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 ## TODOs
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
+1. Look at `opBI` etc label generation doing what blasm.inc does, so local ops don't need `litop op_XXX_code`

--- a/lang/blasm/README.md.tmpl
+++ b/lang/blasm/README.md.tmpl
@@ -18,4 +18,3 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 ## TODOs
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
-1. Follow bluevm convention of `op_name_code` instead of `name.code`, see `op_setthr` in `bth`

--- a/lang/blasm/README.md.tmpl
+++ b/lang/blasm/README.md.tmpl
@@ -19,4 +19,3 @@ To build `blasm` run `make` after `make` has been run in the root of the repo.
 
 1. Add `blasm2` for `.bla2` files that uses `fasm2` for mixed x8664 and blasm
 1. Follow bluevm convention of `op_name_code` instead of `name.code`, see `op_setthr` in `bth`
-1. Rename `callop` to something like `opnum` or `litop`

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -74,7 +74,7 @@ iterate <opname, opsize>, \
 	end match
 end iterate
 
-calminstruction callop op
+calminstruction litop op
 	emit 1, op
 end calminstruction
 

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -60,7 +60,7 @@ iterate <opname, opsize>, \
 	shl, 1, \
 	shr, 1, \
 
-	#opname.code = % - 1
+	op_##opname##_code = % - 1 
 
 	match =1, opsize
 		calminstruction #opname

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -74,6 +74,27 @@ iterate <opname, opsize>, \
 	end match
 end iterate
 
+macro clitX x, val
+	lit##x val
+	c##x
+end macro
+
+macro clitb val
+	clitX b, val
+end macro
+
+macro clitw val
+	clitX w, val
+end macro
+
+macro clitd val
+	clitX d, val
+end macro
+
+macro clitq val
+	clitX q, val
+end macro
+
 calminstruction litop op
 	emit 1, op
 end calminstruction

--- a/lang/blasm/blasm.inc.tmpl
+++ b/lang/blasm/blasm.inc.tmpl
@@ -1,7 +1,7 @@
 
 iterate <opname, opsize>, \
 _OPS_
-	#opname.code = % - 1
+	op_##opname##_code = % - 1 
 
 	match =1, opsize
 		calminstruction #opname

--- a/lang/blasm/blasm.inc.tmpl
+++ b/lang/blasm/blasm.inc.tmpl
@@ -15,6 +15,27 @@ _OPS_
 	end match
 end iterate
 
+macro clitX x, val
+	lit##x val
+	c##x
+end macro
+
+macro clitb val
+	clitX b, val
+end macro
+
+macro clitw val
+	clitX w, val
+end macro
+
+macro clitd val
+	clitX d, val
+end macro
+
+macro clitq val
+	clitX q, val
+end macro
+
 calminstruction litop op
 	emit 1, op
 end calminstruction

--- a/lang/blasm/blasm.inc.tmpl
+++ b/lang/blasm/blasm.inc.tmpl
@@ -15,7 +15,7 @@ _OPS_
 	end match
 end iterate
 
-calminstruction callop op
+calminstruction litop op
 	emit 1, op
 end calminstruction
 

--- a/test/call.bla
+++ b/test/call.bla
@@ -132,10 +132,10 @@ litb	0x09
 blk
 dup
 
-litb	ok.code
+litb	op_ok_code
 setincb
 
-litb	ret.code
+litb	op_ret_code
 setb
 
 call
@@ -144,10 +144,10 @@ litb	0x05
 blk
 dup
 
-litb	ok.code
+litb	op_ok_code
 setincb
 
-litb	ret.code
+litb	op_ret_code
 setb
 
 call

--- a/test/comp.bla
+++ b/test/comp.bla
@@ -13,30 +13,30 @@ plan
 comp
 endcomp
 depth
-litb 0x01
+litb	0x01
 okeq
 drop
 
 comp
 endcomp
 atb
-litb ret.code
+litb	op_ret_code
 okeq
 
 comp
 endcomp
-litb 0x01
+litb	0x01
 sub
 atb
-litb setip.code
+litb	op_setip_code
 okeq
 
 comp
 endcomp
-litb 0x0A
+litb	0x0A
 sub
 atb
-litb litq.code
+litb	op_litq_code
 okeq
 
 comp

--- a/test/extoprt.bla
+++ b/test/extoprt.bla
@@ -35,7 +35,7 @@ setq
 depth
 litb	0x00
 eq
-callop	0xFF
+litop	0xFF
 
 ;
 ; implement extended opcode 0xFF to add 7 to the top of the stack
@@ -62,7 +62,7 @@ setb
 
 ; call ext opcode to check initial value is 0
 litb	0x03
-callop	0xFF
+litop	0xFF
 litb	0x0A
 okeq
 

--- a/test/extoprt.bla
+++ b/test/extoprt.bla
@@ -51,13 +51,13 @@ litb	0x01
 setincb
 
 ; compile bytecode into the opcode table
-litb	litb.code
+litb	op_litb_code
 setincb
 litb	0x07
 setincb
-litb	add.code
+litb	op_add_code
 setincb
-litb	ret.code
+litb	op_ret_code
 setb
 
 ; call ext opcode to check initial value is 0

--- a/test/here.bla
+++ b/test/here.bla
@@ -16,7 +16,7 @@ litb	0x07
 blk
 litb	0x05
 add
-litb	here.code
+litb	op_here_code
 setvarq
 litb	0x07
 blk
@@ -25,7 +25,7 @@ okne
 
 litb	0x07
 blk
-litb	here.code
+litb	op_here_code
 setvarq
 litb	0x07
 blk

--- a/test/mccall.bla
+++ b/test/mccall.bla
@@ -8,8 +8,7 @@ plan
 
 ; call address that immediately returns
 here
-litb	0xC3
-cb
+clitb	0xC3
 mccall
 ok
 

--- a/test/setvar.bla
+++ b/test/setvar.bla
@@ -20,11 +20,11 @@ litb	0x01
 setincb
 
 ; compile bytecode into the opcode table
-litb	litb.code
+litb	op_litb_code
 setincb
 litb	0x00
 setincb
-litb	ret.code
+litb	op_ret_code
 setb
 
 ; call ext opcode to check initial value is 0
@@ -55,11 +55,11 @@ litb	0x01
 setincb
 
 ; compile bytecode into the opcode table
-litb	litw.code
+litb	op_litw_code
 setincb
 litb	0x00
 setincw
-litb	ret.code
+litb	op_ret_code
 setb
 
 ; call ext opcode to check initial value is 0
@@ -90,11 +90,11 @@ litb	0x01
 setincb
 
 ; compile bytecode into the opcode table
-litb	litd.code
+litb	op_litd_code
 setincb
 litb	0x00
 setincd
-litb	ret.code
+litb	op_ret_code
 setb
 
 ; call ext opcode to check initial value is 0
@@ -125,11 +125,11 @@ litb	0x01
 setincb
 
 ; compile bytecode into the opcode table
-litb	litq.code
+litb	op_litq_code
 setincb
 litb	0x00
 setincq
-litb	ret.code
+litb	op_ret_code
 setb
 
 ; call ext opcode to check initial value is 0

--- a/test/setvar.bla
+++ b/test/setvar.bla
@@ -28,7 +28,7 @@ litb	ret.code
 setb
 
 ; call ext opcode to check initial value is 0
-callop	0xFF
+litop	0xFF
 ok0
 
 ; set its value
@@ -38,7 +38,7 @@ litb	0xFF
 setvarb
 
 ; call ext opcode to check updated value
-callop	0xFF
+litop	0xFF
 okeq
 
 ;
@@ -63,7 +63,7 @@ litb	ret.code
 setb
 
 ; call ext opcode to check initial value is 0
-callop	0xFF
+litop	0xFF
 ok0
 
 ; set its value
@@ -73,7 +73,7 @@ litb	0xFF
 setvarw
 
 ; call ext opcode to check updated value
-callop	0xFF
+litop	0xFF
 okeq
 
 ;
@@ -98,7 +98,7 @@ litb	ret.code
 setb
 
 ; call ext opcode to check initial value is 0
-callop	0xFF
+litop	0xFF
 ok0
 
 ; set its value
@@ -108,7 +108,7 @@ litb	0xFF
 setvard
 
 ; call ext opcode to check updated value
-callop	0xFF
+litop	0xFF
 okeq
 
 ;
@@ -133,7 +133,7 @@ litb	ret.code
 setb
 
 ; call ext opcode to check initial value is 0
-callop	0xFF
+litop	0xFF
 ok0
 
 ; set its value
@@ -143,7 +143,7 @@ litb	0xFF
 setvarq
 
 ; call ext opcode to check updated value
-callop	0xFF
+litop	0xFF
 okeq
 
 done

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -40,7 +40,7 @@ iterate <opname, opsize>, \
 	okn0, 1, \
 	done, 1, \
 
-	#opname.code = % - 1 + 0x80
+	op_##opname##_code = % - 1 + 0x80 
 
 	match =1, opsize
 		calminstruction #opname

--- a/tools/bth/bth.inc.tmpl
+++ b/tools/bth/bth.inc.tmpl
@@ -1,7 +1,7 @@
 
 iterate <opname, opsize>, \
 _LOW_OPS_
-	#opname.code = % - 1 + 0x80
+	op_##opname##_code = % - 1 + 0x80 
 
 	match =1, opsize
 		calminstruction #opname

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -46,8 +46,7 @@ opBI	op_cmovd, 1, 0	;	( d b -- )	Compile mov b, dword
 end_op
 
 opBI	op_cmovq, 1, 0	;	( q b -- )	Compile mov b, qword
-	litb	0x48
-	cb
+	clitb	0x48
 	litb	0xB8
 	or
 	cb
@@ -56,26 +55,22 @@ opBI	op_cmovq, 1, 0	;	( q b -- )	Compile mov b, qword
 end_op
 
 opBI	op_cret, 1, 0	;	( -- )	Compile ret
-	litb	0xC3
-	cb
+	clitb	0xC3
 	ret
 end_op
 
 opBI	op_cstosd, 1, 0	;	( -- )	Compile stosd
-	litb	0xAB
-	cb
+	clitb	0xAB
 	ret
 end_op
 
 opBI	op_csys, 1, 0	;	( -- )	Compile syscall
-	litw	0x050F
-	cw
+	clitw	0x050F
 	ret
 end_op
 
 opBI	op_cxord, 1, 0	;	( b -- )	Compile xor b, b
-	litb	0x31
-	cb
+	clitb	0x31
 	dup
 	litb	0x03
 	shl
@@ -230,19 +225,15 @@ opBI	op_wprep, 1, 0	;	( -- )	Preps the write system call
 	; xor eax, eax
 	; inc eax
 	; mov edi, eax
-	litw	0xC031
-	cw
-	litw	0xC0FF
-	cw
-	litw	0xC789
-	cw
+	clitw	0xC031
+	clitw	0xC0FF
+	clitw	0xC789
 	ret
 end_op
 
 opBI	op_wlen, 1, 0	;	( -- )	Buffer length for the write system call
 	; mov edx, _buffer len_
-	litb	0xBA
-	cb
+	clitb	0xBA
 	litop	op_thr_code
 	litop	op_oblk_code
 	sub
@@ -252,8 +243,7 @@ end_op
 
 opBI	op_waddr, 1, 0	;	( -- )	Addr of the buffer for the write system call
 	; movabs rsi, _addr of string_
-	litw	0xBE48
-	cw
+	clitw	0xBE48
 	litop	op_oblk_code
 	cq
 	ret

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -33,7 +33,7 @@ opBI	op_chkargc, 1, 0	;	( -- )	Exit with error unless argc is 2
 		litb	0x01
 		exit
 	endcomp
-	callop	op_ifnot_code
+	litop	op_ifnot_code
 	ret
 end_op
 
@@ -114,21 +114,21 @@ opBI	op_cdstarg, 1, 0	;	( -- )	Compile movabs rdi, _addr of argv[1]_
 	add
 	atq
 	litb	RDI
-	callop	op_cmovq_code
+	litop	op_cmovq_code
 	ret
 end_op
 
 opBI	op_cflgsro, 1, 0	;	( -- )	Compile xor esi, esi (flags = READ_ONLY)
 	litb	ESI
-	callop	op_cxord_code
+	litop	op_cxord_code
 	ret
 end_op
 
 opBI	op_csopen, 1, 0	;	( -- )	Compile mov eax, 0x02 (sys_open); syscall
 	litb	SYS_OPEN
 	litb	EAX
-	callop	op_cmovd_code
-	callop	op_csys_code
+	litop	op_cmovd_code
+	litop	op_csys_code
 	ret
 end_op
 
@@ -138,14 +138,14 @@ opBI	op_cdsttfd, 1, 0	;	( -- )	Compile movabs rdi, _addr of tfd's litd_
 	litb	0x03
 	add
 	litb	RDI
-	callop	op_cmovq_code
+	litop	op_cmovq_code
 	ret
 end_op
 
 opBI	op_cfrmtfd, 1, 0	;	( -- )	Compile mov edi, _tfd_
-	callop	op_tfd_code
+	litop	op_tfd_code
 	litb	EDI
-	callop	op_cmovd_code
+	litop	op_cmovd_code
 	ret
 end_op
 
@@ -153,34 +153,34 @@ opBI	op_csrctib, 1, 0	;	( -- )	Compile mov rsi, _addr of _test input block_
 	litb	BLK_TEST_INPUT
 	blk
 	litb	RSI
-	callop	op_cmovq_code
+	litop	op_cmovq_code
 	ret
 end_op
 
 opBI	op_cblklen, 1, 0	;	( -- )	Compile mov edx, 0x0400
 	litw	0x400
 	litb	EDX
-	callop	op_cmovd_code
+	litop	op_cmovd_code
 	ret
 end_op
 
 opBI	op_csread, 1, 0	;	( -- )	Compile xor eax, eax; syscall
 	litb	EAX
-	callop	op_cxord_code
-	callop	op_csys_code
+	litop	op_cxord_code
+	litop	op_csys_code
 	ret
 end_op
 
 opBI	op_opentst, 1, 0	;	( -- )	Open argv[1] and set tfd
 	here
 	
-	callop	op_cdstarg_code
-	callop	op_cflgsro_code
-	callop	op_csopen_code
+	litop	op_cdstarg_code
+	litop	op_cflgsro_code
+	litop	op_csopen_code
 
-	callop	op_cdsttfd_code
-	callop	op_cstosd_code
-	callop	op_cret_code
+	litop	op_cdsttfd_code
+	litop	op_cstosd_code
+	litop	op_cret_code
 
 	mccall
 	; TODO: check fd
@@ -190,11 +190,11 @@ end_op
 opBI	op_readtst, 1, 0	;	( -- )	Read block from tfd into the test input block
 	here
 
-	callop	op_cfrmtfd_code
-	callop	op_csrctib_code
-	callop	op_cblklen_code
-	callop	op_csread_code
-	callop	op_cret_code
+	litop	op_cfrmtfd_code
+	litop	op_csrctib_code
+	litop	op_cblklen_code
+	litop	op_csread_code
+	litop	op_cret_code
 
 	mccall
 	ret
@@ -215,14 +215,14 @@ end_op
 opBI	op_endl, 1, 0	;	( a -- )	End line of output and set TAP output's here
 	litb	0x0A
 	setincb
-	callop	op_setthr_code
+	litop	op_setthr_code
 	ret
 end_op
 
 opBI	op_woka, 1, 0	;	( a -- )	Write ok line to addr
 	litw	'ok'
 	setincw
-	callop	op_endl_code
+	litop	op_endl_code
 	ret
 end_op
 
@@ -243,8 +243,8 @@ opBI	op_wlen, 1, 0	;	( -- )	Buffer length for the write system call
 	; mov edx, _buffer len_
 	litb	0xBA
 	cb
-	callop	op_thr_code
-	callop	op_oblk_code
+	litop	op_thr_code
+	litop	op_oblk_code
 	sub
 	cd
 	ret
@@ -254,7 +254,7 @@ opBI	op_waddr, 1, 0	;	( -- )	Addr of the buffer for the write system call
 	; movabs rsi, _addr of string_
 	litw	0xBE48
 	cw
-	callop	op_oblk_code
+	litop	op_oblk_code
 	cq
 	ret
 end_op
@@ -262,43 +262,43 @@ end_op
 ;;;
 
 opBI	op_test, 1, 0	;	( w -- )	Initialize a test suite
-	callop	op_oblk_code
-	callop	op_setthr_code
+	litop	op_oblk_code
+	litop	op_setthr_code
 	ret
 end_op
 
 opBI	op_plan, 1, 0	;	( w -- )	Plan w tests where w is two ascii characters such as '03'
-	callop	op_thr_code
+	litop	op_thr_code
 	litw	'1.'
 	setincw
 	litb	'.'
 	setincb
 	swap
 	setincw
-	callop	op_endl_code
+	litop	op_endl_code
 	ret
 end_op
 
 opBI	op_ok, 1, 0	;	( -- )	Write ok line to TAP output's here
-	callop	op_thr_code
-	callop	op_woka_code
+	litop	op_thr_code
+	litop	op_woka_code
 	ret
 end_op
 
 opBI	op_notok, 1, 0	;	( -- )	Write not ok line to TAP output's here
-	callop	op_thr_code
+	litop	op_thr_code
 	litd	'not '
 	setincd
-	callop	op_woka_code
+	litop	op_woka_code
 	ret
 end_op
 
 opBI	op_okif, 1, 0	;	( t/f -- )	Ok if top of stack is true
 	comp
-		callop	op_ok_code
+		litop	op_ok_code
 	endcomp
 	comp
-		callop	op_notok_code
+		litop	op_notok_code
 	endcomp
 	ifelse
 	ret
@@ -306,21 +306,21 @@ end_op
 
 opBI	op_okeq, 1, 0	;	( a b -- )	Ok if a and b are eq
 	eq
-	callop	op_okif_code
+	litop	op_okif_code
 	ret
 end_op
 
 opBI	op_okne, 1, 0	;	( a b -- )	Ok if a and b are not eq
 	eq
 	not
-	callop	op_okif_code
+	litop	op_okif_code
 	ret
 end_op
 
 opBI	op_ok0, 1, 0	;	( n -- )	Ok if top of stack is 0
 	litb	0x00
 	eq
-	callop	op_okif_code
+	litop	op_okif_code
 	ret
 end_op
 
@@ -328,17 +328,17 @@ opBI	op_okn0, 1, 0	;	( n -- )	Ok if top of stack is not 0
 	litb	0x00
 	eq
 	not
-	callop	op_okif_code
+	litop	op_okif_code
 	ret
 end_op
 
 opBI	op_done, 1, 0	;	( -- )	Writes TAP output to stdout and exits with depth as status
 	here
-	callop	op_wprep_code
-	callop	op_wlen_code
-	callop	op_waddr_code
-	callop	op_csys_code
-	callop	op_cret_code
+	litop	op_wprep_code
+	litop	op_wlen_code
+	litop	op_waddr_code
+	litop	op_csys_code
+	litop	op_cret_code
 	mccall
 	depth
 	exit

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -203,7 +203,7 @@ end_op
 opBI	op_runtst, 1, 0	;	( -- )	Run the test in the test input block
 	litb	BLK_CODE
 	blk
-	litb	here.code
+	litb	op_here_code
 	setvarq
 
 	litb	BLK_TEST_INPUT


### PR DESCRIPTION
1. Removed `opname.code` vs `op_opname_code` inconsistency
2. Added `clit{b,w,d,q}` macros
3. Renamed `callop` to `litop`