### PR TITLE
Remove `set` and `at` opcode variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,30 +124,26 @@ Opcodes are subject to change.
 | 0x1B | setincw | ( a w -- 'a ) | Write word value to, increment and push addr |
 | 0x1C | setincd | ( a d -- 'a ) | Write dword value to, increment and push addr |
 | 0x1D | setincq | ( a q -- 'a ) | Write qword value to, increment and push addr |
-| 0x1E | setb | ( a b -- ) | Write byte value to addr |
-| 0x1F | setw | ( a w -- ) | Write word value to addr |
-| 0x20 | setd | ( a d -- ) | Write dword value to addr |
-| 0x21 | setq | ( a q -- ) | Write qword value to addr |
-| 0x22 | cb | ( b -- ) | Write byte value to and increment here |
-| 0x23 | cw | ( w -- ) | Write word value to and increment here |
-| 0x24 | cd | ( d -- ) | Write dword value to and increment here |
-| 0x25 | cq | ( q -- ) | Write qword value to and increment here |
-| 0x26 | litb | ( -- b ) | Push next byte from and increment instruction pointer |
-| 0x27 | litw | ( -- w ) | Push next word from and increment instruction pointer |
-| 0x28 | litd | ( -- d ) | Push next dword from and increment instruction pointer |
-| 0x29 | litq | ( -- q ) | Push next qword from and increment instruction pointer |
-| 0x2A | depth | ( -- n ) | Push depth of the data stack |
-| 0x2B | dup | ( x -- ) | Drops top of the data stack |
-| 0x2C | drop | ( a -- a a ) | Duplicate top of stack |
-| 0x2D | swap | ( a b -- b a ) | Swap top two values on the data stack |
-| 0x2E | not | ( x -- 'x ) | Bitwise not top of the data stack |
-| 0x2F | eq | ( a b -- t/f ) | Check top two items for equality and push result |
-| 0x30 | add | ( a b -- n ) | Push a + b |
-| 0x31 | sub | ( a b -- n ) | Push a - b |
-| 0x32 | and | ( a b -- n ) | Push logical and of a and b |
-| 0x33 | or | ( a b -- n ) | Push logical inclusive or of a and b |
-| 0x34 | shl | ( x n -- 'x ) | Push x shl n |
-| 0x35 | shr | ( x n -- 'x ) | Push x shr n |
+| 0x1E | cb | ( b -- ) | Write byte value to and increment here |
+| 0x1F | cw | ( w -- ) | Write word value to and increment here |
+| 0x20 | cd | ( d -- ) | Write dword value to and increment here |
+| 0x21 | cq | ( q -- ) | Write qword value to and increment here |
+| 0x22 | litb | ( -- b ) | Push next byte from and increment instruction pointer |
+| 0x23 | litw | ( -- w ) | Push next word from and increment instruction pointer |
+| 0x24 | litd | ( -- d ) | Push next dword from and increment instruction pointer |
+| 0x25 | litq | ( -- q ) | Push next qword from and increment instruction pointer |
+| 0x26 | depth | ( -- n ) | Push depth of the data stack |
+| 0x27 | dup | ( x -- ) | Drops top of the data stack |
+| 0x28 | drop | ( a -- a a ) | Duplicate top of stack |
+| 0x29 | swap | ( a b -- b a ) | Swap top two values on the data stack |
+| 0x2A | not | ( x -- 'x ) | Bitwise not top of the data stack |
+| 0x2B | eq | ( a b -- t/f ) | Check top two items for equality and push result |
+| 0x2C | add | ( a b -- n ) | Push a + b |
+| 0x2D | sub | ( a b -- n ) | Push a - b |
+| 0x2E | and | ( a b -- n ) | Push logical and of a and b |
+| 0x2F | or | ( a b -- n ) | Push logical inclusive or of a and b |
+| 0x30 | shl | ( x n -- 'x ) | Push x shl n |
+| 0x31 | shr | ( x n -- 'x ) | Push x shr n |
 
 ### Extended Low/High
 
@@ -170,7 +166,8 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. Rename `op_op` to `op_opent` or similar
+1. Rename `op_op` to `op_opaddr`
+1. Reorder opcodes again
 1. Bug: add/remove ops and `make` fails until `make clean`
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, op_cb, etc

--- a/README.md
+++ b/README.md
@@ -120,38 +120,34 @@ Opcodes are subject to change.
 | 0x17 | atincw | ( a -- w a' ) | Push word value found at addr, increment and push addr |
 | 0x18 | atincd | ( a -- d a' ) | Push dword value found at addr, increment and push addr |
 | 0x19 | atincq | ( a -- q a' ) | Push qword value found at addr, increment and push addr |
-| 0x1A | atb | ( a -- b ) | Push byte value found at addr |
-| 0x1B | atw | ( a -- d ) | Push word value found at addr |
-| 0x1C | atd | ( a -- w ) | Push dword value found at addr |
-| 0x1D | atq | ( a -- q ) | Push qword value found at addr |
-| 0x1E | setincb | ( a b -- 'a ) | Write byte value to, increment and push addr |
-| 0x1F | setincw | ( a w -- 'a ) | Write word value to, increment and push addr |
-| 0x20 | setincd | ( a d -- 'a ) | Write dword value to, increment and push addr |
-| 0x21 | setincq | ( a q -- 'a ) | Write qword value to, increment and push addr |
-| 0x22 | setb | ( a b -- ) | Write byte value to addr |
-| 0x23 | setw | ( a w -- ) | Write word value to addr |
-| 0x24 | setd | ( a d -- ) | Write dword value to addr |
-| 0x25 | setq | ( a q -- ) | Write qword value to addr |
-| 0x26 | cb | ( b -- ) | Write byte value to and increment here |
-| 0x27 | cw | ( w -- ) | Write word value to and increment here |
-| 0x28 | cd | ( d -- ) | Write dword value to and increment here |
-| 0x29 | cq | ( q -- ) | Write qword value to and increment here |
-| 0x2A | litb | ( -- b ) | Push next byte from and increment instruction pointer |
-| 0x2B | litw | ( -- w ) | Push next word from and increment instruction pointer |
-| 0x2C | litd | ( -- d ) | Push next dword from and increment instruction pointer |
-| 0x2D | litq | ( -- q ) | Push next qword from and increment instruction pointer |
-| 0x2E | depth | ( -- n ) | Push depth of the data stack |
-| 0x2F | dup | ( x -- ) | Drops top of the data stack |
-| 0x30 | drop | ( a -- a a ) | Duplicate top of stack |
-| 0x31 | swap | ( a b -- b a ) | Swap top two values on the data stack |
-| 0x32 | not | ( x -- 'x ) | Bitwise not top of the data stack |
-| 0x33 | eq | ( a b -- t/f ) | Check top two items for equality and push result |
-| 0x34 | add | ( a b -- n ) | Push a + b |
-| 0x35 | sub | ( a b -- n ) | Push a - b |
-| 0x36 | and | ( a b -- n ) | Push logical and of a and b |
-| 0x37 | or | ( a b -- n ) | Push logical inclusive or of a and b |
-| 0x38 | shl | ( x n -- 'x ) | Push x shl n |
-| 0x39 | shr | ( x n -- 'x ) | Push x shr n |
+| 0x1A | setincb | ( a b -- 'a ) | Write byte value to, increment and push addr |
+| 0x1B | setincw | ( a w -- 'a ) | Write word value to, increment and push addr |
+| 0x1C | setincd | ( a d -- 'a ) | Write dword value to, increment and push addr |
+| 0x1D | setincq | ( a q -- 'a ) | Write qword value to, increment and push addr |
+| 0x1E | setb | ( a b -- ) | Write byte value to addr |
+| 0x1F | setw | ( a w -- ) | Write word value to addr |
+| 0x20 | setd | ( a d -- ) | Write dword value to addr |
+| 0x21 | setq | ( a q -- ) | Write qword value to addr |
+| 0x22 | cb | ( b -- ) | Write byte value to and increment here |
+| 0x23 | cw | ( w -- ) | Write word value to and increment here |
+| 0x24 | cd | ( d -- ) | Write dword value to and increment here |
+| 0x25 | cq | ( q -- ) | Write qword value to and increment here |
+| 0x26 | litb | ( -- b ) | Push next byte from and increment instruction pointer |
+| 0x27 | litw | ( -- w ) | Push next word from and increment instruction pointer |
+| 0x28 | litd | ( -- d ) | Push next dword from and increment instruction pointer |
+| 0x29 | litq | ( -- q ) | Push next qword from and increment instruction pointer |
+| 0x2A | depth | ( -- n ) | Push depth of the data stack |
+| 0x2B | dup | ( x -- ) | Drops top of the data stack |
+| 0x2C | drop | ( a -- a a ) | Duplicate top of stack |
+| 0x2D | swap | ( a b -- b a ) | Swap top two values on the data stack |
+| 0x2E | not | ( x -- 'x ) | Bitwise not top of the data stack |
+| 0x2F | eq | ( a b -- t/f ) | Check top two items for equality and push result |
+| 0x30 | add | ( a b -- n ) | Push a + b |
+| 0x31 | sub | ( a b -- n ) | Push a - b |
+| 0x32 | and | ( a b -- n ) | Push logical and of a and b |
+| 0x33 | or | ( a b -- n ) | Push logical inclusive or of a and b |
+| 0x34 | shl | ( x n -- 'x ) | Push x shl n |
+| 0x35 | shr | ( x n -- 'x ) | Push x shr n |
 
 ### Extended Low/High
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -115,7 +115,8 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. Rename `op_op` to `op_opent` or similar
+1. Rename `op_op` to `op_opaddr`
+1. Reorder opcodes again
 1. Bug: add/remove ops and `make` fails until `make clean`
 1. setq, etc stack effects feel backwards when not in test code
    1. see swap in op_setvarq, op_cb, etc

--- a/bluevm_defs.inc
+++ b/bluevm_defs.inc
@@ -59,9 +59,3 @@ macro end_op
 	end repeat
 	assert ($ - latest_op) = (CELL_SIZE * 2)
 end macro
-
-macro cx w
-	db op_here_code, op_swap_code, op_setinc##w##_code
-	db op_litb_code, op_here_code, op_setvarq_code
-	db op_ret_code
-end macro

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -27,10 +27,6 @@ iterate <opname, opsize>, \
 	atincw, 1, \
 	atincd, 1, \
 	atincq, 1, \
-	atb, 1, \
-	atw, 1, \
-	atd, 1, \
-	atq, 1, \
 	setincb, 1, \
 	setincw, 1, \
 	setincd, 1, \

--- a/lang/blasm/blasm.inc
+++ b/lang/blasm/blasm.inc
@@ -31,10 +31,6 @@ iterate <opname, opsize>, \
 	setincw, 1, \
 	setincd, 1, \
 	setincq, 1, \
-	setb, 1, \
-	setw, 1, \
-	setd, 1, \
-	setq, 1, \
 	cb, 1, \
 	cw, 1, \
 	cd, 1, \

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -141,22 +141,6 @@ opNI	op_atincq, 1, 0	;	( a -- q a' )	Push qword value found at addr, increment a
 	jmp	_atinc_post
 end_op
 
-opBI	op_atb, 1, 0	;	( a -- b )	Push byte value found at addr
-	db op_atincb_code, op_drop_code, op_ret_code
-end_op
-
-opBI	op_atw, 1, 0	;	( a -- d )	Push word value found at addr
-	db op_atincw_code, op_drop_code, op_ret_code
-end_op
-
-opBI	op_atd, 1, 0	;	( a -- w )	Push dword value found at addr
-	db op_atincd_code, op_drop_code, op_ret_code
-end_op
-	
-opBI	op_atq, 1, 0	;	( a -- q )	Push qword value found at addr
-	db op_atincq_code, op_drop_code, op_ret_code
-end_op	
-
 opNI	op_setincb, 1, 0	;	( a b -- 'a )	Write byte value to, increment and push addr
 	call 	_set_pre
 	stosb
@@ -201,6 +185,12 @@ end_op
 opBI	op_setq, 1, 0	;	( a q -- )	Write qword value to addr
 	db op_setincq_code, op_drop_code, op_ret_code
 end_op
+
+macro cx w
+	db op_here_code, op_swap_code, op_setinc##w##_code
+	db op_litb_code, op_here_code, op_setvarq_code
+	db op_ret_code
+end macro
 
 opBI	op_cb, 1, 0	;	( b -- )	Write byte value to and increment here
 	cx	b

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -77,20 +77,25 @@ opN	op_endcomp, 1, OPCODE_ENTRY_FLAG_IMMEDIATE	;	( -- a )	Append ret and end com
 
 opN	op_op, 1, 0	;	( b -- a )	Push addr of the offset into the op table for the opcode
 
+macro setvarx x
+	db op_op_code, op_litb_code, 0x03, op_add_code
+	db op_swap_code, op_setinc##x##_code, op_drop_code, op_ret_code
+end macro
+
 opBI	op_setvarb, 1, 0	;	( b b -- )	Set litb value of var op
-	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setb_code, op_ret_code
+	setvarx b
 end_op
 
 opBI	op_setvarw, 1, 0	;	( w b -- )	Set litw value of var op
-	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setw_code, op_ret_code
+	setvarx w
 end_op
 
 opBI	op_setvard, 1, 0	;	( d b -- )	Set litd value of var op
-	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setd_code, op_ret_code
+	setvarx d
 end_op
 
 opBI	op_setvarq, 1, 0	;	( q b -- )	Set litq value of var op
-	db op_op_code, op_litb_code, 0x03, op_add_code, op_swap_code, op_setq_code, op_ret_code
+	setvarx q
 end_op
 
 opNI	op_ip, 1, 0	;	( -- a )	Push location of the instruction pointer
@@ -170,24 +175,8 @@ opNI	op_setincq, 1, 0	;	( a q -- 'a )	Write qword value to, increment and push a
 	jmp	_set_post
 end_op
 
-opBI	op_setb, 1, 0	;	( a b -- )	Write byte value to addr
-	db op_setincb_code, op_drop_code, op_ret_code
-end_op
-
-opBI	op_setw, 1, 0	;	( a w -- )	Write word value to addr
-	db op_setincw_code, op_drop_code, op_ret_code
-end_op
-
-opBI	op_setd, 1, 0	;	( a d -- )	Write dword value to addr
-	db op_setincd_code, op_drop_code, op_ret_code
-end_op
-
-opBI	op_setq, 1, 0	;	( a q -- )	Write qword value to addr
-	db op_setincq_code, op_drop_code, op_ret_code
-end_op
-
-macro cx w
-	db op_here_code, op_swap_code, op_setinc##w##_code
+macro cx x
+	db op_here_code, op_swap_code, op_setinc##x##_code
 	db op_litb_code, op_here_code, op_setvarq_code
 	db op_ret_code
 end macro

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -79,7 +79,8 @@ opN	op_op, 1, 0	;	( b -- a )	Push addr of the offset into the op table for the o
 
 macro setvarx x
 	db op_op_code, op_litb_code, 0x03, op_add_code
-	db op_swap_code, op_setinc##x##_code, op_drop_code, op_ret_code
+	db op_swap_code, op_setinc##x##_code, op_drop_code
+	db op_ret_code
 end macro
 
 opBI	op_setvarb, 1, 0	;	( b b -- )	Set litb value of var op

--- a/ops_vm.tbl
+++ b/ops_vm.tbl
@@ -24,10 +24,6 @@ atincb	1	( a -- b a' )	Push byte value found at addr, increment and push addr
 atincw	1	( a -- w a' )	Push word value found at addr, increment and push addr
 atincd	1	( a -- d a' )	Push dword value found at addr, increment and push addr
 atincq	1	( a -- q a' )	Push qword value found at addr, increment and push addr
-atb	1	( a -- b )	Push byte value found at addr
-atw	1	( a -- d )	Push word value found at addr
-atd	1	( a -- w )	Push dword value found at addr
-atq	1	( a -- q )	Push qword value found at addr
 setincb	1	( a b -- 'a )	Write byte value to, increment and push addr
 setincw	1	( a w -- 'a )	Write word value to, increment and push addr
 setincd	1	( a d -- 'a )	Write dword value to, increment and push addr

--- a/ops_vm.tbl
+++ b/ops_vm.tbl
@@ -28,10 +28,6 @@ setincb	1	( a b -- 'a )	Write byte value to, increment and push addr
 setincw	1	( a w -- 'a )	Write word value to, increment and push addr
 setincd	1	( a d -- 'a )	Write dword value to, increment and push addr
 setincq	1	( a q -- 'a )	Write qword value to, increment and push addr
-setb	1	( a b -- )	Write byte value to addr
-setw	1	( a w -- )	Write word value to addr
-setd	1	( a d -- )	Write dword value to addr
-setq	1	( a q -- )	Write qword value to addr
 cb	1	( b -- )	Write byte value to and increment here
 cw	1	( w -- )	Write word value to and increment here
 cd	1	( d -- )	Write dword value to and increment here

--- a/test/call.bla
+++ b/test/call.bla
@@ -136,7 +136,8 @@ litb	op_ok_code
 setincb
 
 litb	op_ret_code
-setb
+setincb
+drop
 
 call
 
@@ -148,7 +149,8 @@ litb	op_ok_code
 setincb
 
 litb	op_ret_code
-setb
+setincb
+drop
 
 call
 

--- a/test/comp.bla
+++ b/test/comp.bla
@@ -19,7 +19,8 @@ drop
 
 comp
 endcomp
-atb
+atincb
+drop
 litb	op_ret_code
 okeq
 
@@ -27,7 +28,8 @@ comp
 endcomp
 litb	0x01
 sub
-atb
+atincb
+drop
 litb	op_setip_code
 okeq
 
@@ -35,7 +37,8 @@ comp
 endcomp
 litb	0x0A
 sub
-atb
+atincb
+drop
 litb	op_litq_code
 okeq
 

--- a/test/extoprt.bla
+++ b/test/extoprt.bla
@@ -29,7 +29,8 @@ comp
 	endcomp
 	ifelse
 endcomp
-setq
+setincq
+drop
 
 ; call ext opcode to check that stack depth is 0
 depth
@@ -58,7 +59,8 @@ setincb
 litb	op_add_code
 setincb
 litb	op_ret_code
-setb
+setincb
+drop
 
 ; call ext opcode to check initial value is 0
 litb	0x03

--- a/test/setvar.bla
+++ b/test/setvar.bla
@@ -25,7 +25,8 @@ setincb
 litb	0x00
 setincb
 litb	op_ret_code
-setb
+setincb
+drop
 
 ; call ext opcode to check initial value is 0
 litop	0xFF
@@ -60,7 +61,8 @@ setincb
 litb	0x00
 setincw
 litb	op_ret_code
-setb
+setincb
+drop
 
 ; call ext opcode to check initial value is 0
 litop	0xFF
@@ -95,7 +97,8 @@ setincb
 litb	0x00
 setincd
 litb	op_ret_code
-setb
+setincb
+drop
 
 ; call ext opcode to check initial value is 0
 litop	0xFF
@@ -130,7 +133,8 @@ setincb
 litb	0x00
 setincq
 litb	op_ret_code
-setb
+setincb
+drop
 
 ; call ext opcode to check initial value is 0
 litop	0xFF

--- a/test/write.bla
+++ b/test/write.bla
@@ -47,7 +47,8 @@ cb
 here
 litb	0x01
 sub
-atb
+atincb
+drop
 litb	0xC3
 okeq
 
@@ -61,7 +62,8 @@ cd
 here
 litb	0x04
 sub
-atb
+atincb
+drop
 litb	0xC3
 okeq
 
@@ -75,7 +77,8 @@ cq
 here
 litb	0x08
 sub
-atb
+atincb
+drop
 litb	0xC3
 okeq
 

--- a/tools/bth/README.md
+++ b/tools/bth/README.md
@@ -14,44 +14,46 @@ Opcodes are subject to change and can be used in `.bla` files by including `bth.
 
 | Opcode | Name | Stack Effect | Description |
 |----|----|----|----|
-| 0x80 | ifnot | ( t/f fa -- ? ) | Call fa if t/f is false |
-| 0x81 | chkargc | ( -- ) | Exit with error unless argc is 2 |
-| 0x82 | cmovd | ( d b -- ) | Compile mov b, dword |
-| 0x83 | cmovq | ( q b -- ) | Compile mov b, qword |
-| 0x84 | cret | ( -- ) | Compile ret |
-| 0x85 | cstosd | ( -- ) | Compile stosd |
-| 0x86 | csys | ( -- ) | Compile syscall |
-| 0x87 | cxord | ( b -- ) | Compile xor b, b |
-| 0x88 | tfd | ( -- d ) | Push fd of test input file |
-| 0x89 | oblk | ( -- a ) | Push addr of TAP output's start |
-| 0x8A | thr | ( -- a ) | Push addr of TAP output's here |
-| 0x8B | setthr | ( a -- ) | Set addr of TAP output's here |
-| 0x8C | cdstarg | ( -- ) | Compile movabs rdi, _addr of argv[1]_ |
-| 0x8D | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY) |
-| 0x8E | csopen | ( -- ) | Compile mov eax, 0x02 (sys_open); syscall |
-| 0x8F | cdsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
-| 0x90 | cfrmtfd | ( -- ) | Compile mov edi, _tfd_ |
-| 0x91 | csrctib | ( -- ) | Compile mov rsi, _addr of _test input block_ |
-| 0x92 | cblklen | ( -- ) | Compile mov edx, 0x0400 |
-| 0x93 | csread | ( -- ) | Compile xor eax, eax; syscall |
-| 0x94 | opentst | ( -- ) | Open argv[1] and set tfd |
-| 0x95 | readtst | ( -- ) | Read block from tfd into the test input block |
-| 0x96 | runtst | ( -- ) | Run the test in the test input block |
-| 0x97 | endl | ( a -- ) | End line of output and set TAP output's here |
-| 0x98 | woka | ( a -- ) | Write ok line to addr |
-| 0x99 | wprep | ( -- ) | Preps the write system call |
-| 0x9A | wlen | ( -- ) | Buffer length for the write system call |
-| 0x9B | waddr | ( -- ) | Addr of the buffer for the write system call |
-| 0x9C | test | ( w -- ) | Initialize a test suite |
-| 0x9D | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
-| 0x9E | ok | ( -- ) | Write ok line to TAP output's here |
-| 0x9F | notok | ( -- ) | Write not ok line to TAP output's here |
-| 0xA0 | okif | ( t/f -- ) | Ok if top of stack is true |
-| 0xA1 | okeq | ( a b -- ) | Ok if a and b are eq |
-| 0xA2 | okne | ( a b -- ) | Ok if a and b are not eq |
-| 0xA3 | ok0 | ( n -- ) | Ok if top of stack is 0 |
-| 0xA4 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
-| 0xA5 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
+| 0x80 | atq | ( a -- q ) | Push qword value found at addr |
+| 0x81 | ifnot | ( t/f fa -- ? ) | Call fa if t/f is false |
+| 0x82 | chkargc | ( -- ) | Exit with error unless argc is 2 |
+| 0x83 | cmovd | ( d b -- ) | Compile mov b, dword |
+| 0x84 | cmovq | ( q b -- ) | Compile mov b, qword |
+| 0x85 | cret | ( -- ) | Compile ret |
+| 0x86 | cstosd | ( -- ) | Compile stosd |
+| 0x87 | csys | ( -- ) | Compile syscall |
+| 0x88 | cxord | ( b -- ) | Compile xor b, b |
+| 0x89 | tfd | ( -- d ) | Push fd of test input file |
+| 0x8A | oblk | ( -- a ) | Push addr of TAP output's start |
+| 0x8B | thr | ( -- a ) | Push addr of TAP output's here |
+| 0x8C | setthr | ( a -- ) | Set addr of TAP output's here |
+| 0x8D | argv1 | ( -- a ) | Push argv[1]_ |
+| 0x8E | cdstarg | ( -- ) | Compile movabs rdi, _addr of argv[1]_ |
+| 0x8F | cflgsro | ( -- ) | Compile xor esi, esi (flags = READ_ONLY) |
+| 0x90 | csopen | ( -- ) | Compile mov eax, 0x02 (sys_open); syscall |
+| 0x91 | cdsttfd | ( -- ) | Compile movabs rdi, _addr of tfd's litd_ |
+| 0x92 | cfrmtfd | ( -- ) | Compile mov edi, _tfd_ |
+| 0x93 | csrctib | ( -- ) | Compile mov rsi, _addr of _test input block_ |
+| 0x94 | cblklen | ( -- ) | Compile mov edx, 0x0400 |
+| 0x95 | csread | ( -- ) | Compile xor eax, eax; syscall |
+| 0x96 | opentst | ( -- ) | Open argv[1] and set tfd |
+| 0x97 | readtst | ( -- ) | Read block from tfd into the test input block |
+| 0x98 | runtst | ( -- ) | Run the test in the test input block |
+| 0x99 | endl | ( a -- ) | End line of output and set TAP output's here |
+| 0x9A | woka | ( a -- ) | Write ok line to addr |
+| 0x9B | wprep | ( -- ) | Preps the write system call |
+| 0x9C | wlen | ( -- ) | Buffer length for the write system call |
+| 0x9D | waddr | ( -- ) | Addr of the buffer for the write system call |
+| 0x9E | test | ( w -- ) | Initialize a test suite |
+| 0x9F | plan | ( w -- ) | Plan w tests where w is two ascii characters such as '03' |
+| 0xA0 | ok | ( -- ) | Write ok line to TAP output's here |
+| 0xA1 | notok | ( -- ) | Write not ok line to TAP output's here |
+| 0xA2 | okif | ( t/f -- ) | Ok if top of stack is true |
+| 0xA3 | okeq | ( a b -- ) | Ok if a and b are eq |
+| 0xA4 | okne | ( a b -- ) | Ok if a and b are not eq |
+| 0xA5 | ok0 | ( n -- ) | Ok if top of stack is 0 |
+| 0xA6 | okn0 | ( n -- ) | Ok if top of stack is not 0 |
+| 0xA7 | done | ( -- ) | Writes TAP output to stdout and exits with depth as status |
 
 ## TODOs
 

--- a/tools/bth/bth.inc
+++ b/tools/bth/bth.inc
@@ -1,6 +1,7 @@
 ; Generated from bth.inc.tmpl
 
 iterate <opname, opsize>, \
+	atq, 1, \
 	ifnot, 1, \
 	chkargc, 1, \
 	cmovd, 1, \
@@ -13,6 +14,7 @@ iterate <opname, opsize>, \
 	oblk, 1, \
 	thr, 1, \
 	setthr, 1, \
+	argv1, 1, \
 	cdstarg, 1, \
 	cflgsro, 1, \
 	csopen, 1, \

--- a/tools/bth/ops_low.bla
+++ b/tools/bth/ops_low.bla
@@ -17,6 +17,12 @@ BLK_TEST_OUTPUT = 0x0A
 opcode_tbl:
 .offset = 0x80
 
+opBI	op_atq, 1, 0	;	( a -- q )	Push qword value found at addr
+	atincq
+	drop
+	ret
+end_op
+
 opBI	op_ifnot, 1, 0	;	( t/f fa -- ? )	Call fa if t/f is false
 	comp
 	endcomp
@@ -103,11 +109,16 @@ opBI	op_setthr, 1, 0	;	( a -- )	Set addr of TAP output's here
 	ret
 end_op
 
-opBI	op_cdstarg, 1, 0	;	( -- )	Compile movabs rdi, _addr of argv[1]_
+opBI	op_argv1, 1, 0	;	( -- a )	Push argv[1]_
 	argv
 	litb	0x08
 	add
-	atq
+	litop	op_atq_code
+	ret
+end_op
+
+opBI	op_cdstarg, 1, 0	;	( -- )	Compile movabs rdi, _addr of argv[1]_
+	litop	op_argv1_code
 	litb	RDI
 	litop	op_cmovq_code
 	ret

--- a/tools/bth/ops_low.tbl
+++ b/tools/bth/ops_low.tbl
@@ -1,3 +1,4 @@
+atq	1	( a -- q )	Push qword value found at addr
 ifnot	1	( t/f fa -- ? )	Call fa if t/f is false
 chkargc	1	( -- )	Exit with error unless argc is 2
 cmovd	1	( d b -- )	Compile mov b, dword
@@ -10,6 +11,7 @@ tfd	1	( -- d )	Push fd of test input file
 oblk	1	( -- a )	Push addr of TAP output's start
 thr	1	( -- a )	Push addr of TAP output's here
 setthr	1	( a -- )	Set addr of TAP output's here
+argv1	1	( -- a )	Push argv[1]_
 cdstarg	1	( -- )	Compile movabs rdi, _addr of argv[1]_
 cflgsro	1	( -- )	Compile xor esi, esi (flags = READ_ONLY)
 csopen	1	( -- )	Compile mov eax, 0x02 (sys_open); syscall


### PR DESCRIPTION
These can easily be implemented as ext ops if needed.