### PR TITLE
Dedicate registers for top of stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@ _This file is generated from README.md.tmpl_
 
 # BlueVM
 
-Minimalistic 64 bit virtual machine inspired by Forth and Factor. The BlueVM aims to:
+Minimalistic 64 bit virtual machine inspired by Forth and Factor. This is the reference implementation for
+x86_64 Linux.
+
+The BlueVM aims to:
 
 1. Have a reasonably small, simplistic and hackable codebase
 1. Support execution of any previously compiled machine or bytecode
@@ -149,6 +152,15 @@ Opcodes are subject to change.
 Host applications are free to implement their own opcodes which can be spliced into a BlueVM binary. For an example
 see `tools/bth`.
 
+## Machine Code Contract
+
+If compiling/executing machine code with BlueVM, take note of the reserved registers:
+
+| Register | Purpose |
+|----|----|
+| r12 | Top of Data Stack |
+| r13 | Top of Return Stack |
+
 ## Tools/Examples
 
 Along with the code for BlueVM this repository also contains some tools and examples that can be used as reference:
@@ -169,10 +181,7 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. Add `parse ( b -- a w )` to parse until delim, push addr and length
-1. What if data_stack_here was always in, say rbp?
-   1. Would remove the double dereference
-   1. Double dereference causes suboptimal code when cleaning up the stack after `scall`s
+1. See about dedicated registers for ip, here like data/return stack
 1. Move boot code to bytecode, or maybe better drop it all together
    1. If dropped, need to change tests that `bluevm < test`
 1. Rename code buffer to output buffer

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -1,6 +1,9 @@
 # BlueVM
 
-Minimalistic 64 bit virtual machine inspired by Forth and Factor. The BlueVM aims to:
+Minimalistic 64 bit virtual machine inspired by Forth and Factor. This is the reference implementation for
+x86_64 Linux.
+
+The BlueVM aims to:
 
 1. Have a reasonably small, simplistic and hackable codebase
 1. Support execution of any previously compiled machine or bytecode
@@ -91,6 +94,15 @@ _OPCODE_TABLE_
 Host applications are free to implement their own opcodes which can be spliced into a BlueVM binary. For an example
 see `tools/bth`.
 
+## Machine Code Contract
+
+If compiling/executing machine code with BlueVM, take note of the reserved registers:
+
+| Register | Purpose |
+|----|----|
+| r12 | Top of Data Stack |
+| r13 | Top of Return Stack |
+
 ## Tools/Examples
 
 Along with the code for BlueVM this repository also contains some tools and examples that can be used as reference:
@@ -111,10 +123,7 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. Add `parse ( b -- a w )` to parse until delim, push addr and length
-1. What if data_stack_here was always in, say rbp?
-   1. Would remove the double dereference
-   1. Double dereference causes suboptimal code when cleaning up the stack after `scall`s
+1. See about dedicated registers for ip, here like data/return stack
 1. Move boot code to bytecode, or maybe better drop it all together
    1. If dropped, need to change tests that `bluevm < test`
 1. Rename code buffer to output buffer

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -8,8 +8,11 @@ segment readable writeable executable
 instruction_pointer dq input_buffer
 opcode_handler dq opcode_handler_interpret
 
-return_stack_here dq return_stack
 data_stack_here dq data_stack
+return_stack_here dq return_stack
+
+RS_REG = r13
+SYSCALL_DSH_REG = rbp
 
 include "bluevm_defs.inc"
 include "stack.inc"
@@ -40,6 +43,8 @@ read_boot_code:
 	ret
 
 entry $
+	mov	RS_REG, return_stack
+	
 	mov	rax, [rsp]
 	mov	[argc], rax
 	lea	rax, [rsp+8]

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -8,6 +8,7 @@ segment readable writeable executable
 instruction_pointer dq input_buffer
 opcode_handler dq opcode_handler_interpret
 
+; these registers have app lifetime
 DS_REG = r12
 RS_REG = r13
 

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -8,11 +8,11 @@ segment readable writeable executable
 instruction_pointer dq input_buffer
 opcode_handler dq opcode_handler_interpret
 
+; TODO: remove
 data_stack_here dq data_stack
-return_stack_here dq return_stack
 
+DS_REG = r12
 RS_REG = r13
-SYSCALL_DSH_REG = rbp
 
 include "bluevm_defs.inc"
 include "stack.inc"
@@ -43,6 +43,7 @@ read_boot_code:
 	ret
 
 entry $
+	mov	DS_REG, data_stack
 	mov	RS_REG, return_stack
 	
 	mov	rax, [rsp]

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -8,9 +8,6 @@ segment readable writeable executable
 instruction_pointer dq input_buffer
 opcode_handler dq opcode_handler_interpret
 
-; TODO: remove
-data_stack_here dq data_stack
-
 DS_REG = r12
 RS_REG = r13
 

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -161,6 +161,6 @@ _syscall0:
 	
 	pop	rcx
 	sub	DS_REG, rcx
-
-	call	data_stack_push
+	mov	[DS_REG - CELL_SIZE], rax
+	
 	ret

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -158,13 +158,9 @@ _syscall1:
 _syscall0:
 	mov	rax, [DS_REG - CELL_SIZE]
 	syscall
+	
 	pop	rcx
-	push	rax
+	sub	DS_REG, rcx
 
-.drop:
-	call	data_stack_pop
-	loop	.drop
-
-	pop	rax
 	call	data_stack_push
 	ret

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -138,25 +138,25 @@ _post_lit:
 	ret
 
 _syscall6:
-	mov	r9, [SYSCALL_DSH_REG - (CELL_SIZE * 7)]
+	mov	r9, [DS_REG - (CELL_SIZE * 7)]
 
 _syscall5:
-	mov	r8, [SYSCALL_DSH_REG - (CELL_SIZE * 6)]
+	mov	r8, [DS_REG - (CELL_SIZE * 6)]
 	
 _syscall4:
-	mov	r10, [SYSCALL_DSH_REG - (CELL_SIZE * 5)]
+	mov	r10, [DS_REG - (CELL_SIZE * 5)]
 	
 _syscall3:
-	mov	rdx, [SYSCALL_DSH_REG - (CELL_SIZE * 4)]
+	mov	rdx, [DS_REG - (CELL_SIZE * 4)]
 	
 _syscall2:
-	mov	rsi, [SYSCALL_DSH_REG - (CELL_SIZE * 3)]
+	mov	rsi, [DS_REG - (CELL_SIZE * 3)]
 	
 _syscall1:
-	mov	rdi, [SYSCALL_DSH_REG - (CELL_SIZE * 2)]
+	mov	rdi, [DS_REG - (CELL_SIZE * 2)]
 
 _syscall0:
-	mov	rax, [SYSCALL_DSH_REG - CELL_SIZE]
+	mov	rax, [DS_REG - CELL_SIZE]
 	syscall
 	pop	rcx
 	push	rax

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -137,8 +137,6 @@ _post_lit:
 
 	ret
 
-SYSCALL_DSH_REG = rbp
-
 _syscall6:
 	mov	r9, [SYSCALL_DSH_REG - (CELL_SIZE * 7)]
 

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -16,7 +16,7 @@ opBI	op_argv, 1, 0	;	( -- a )	Push addr of argv
 end_op
 
 macro scallx x
-	push	(x + 1)
+	push	CELL_SIZE * (x + 1)
 	jmp	_syscall##x
 end macro
 

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -16,7 +16,7 @@ opBI	op_argv, 1, 0	;	( -- a )	Push addr of argv
 end_op
 
 macro scallx x
-	push	CELL_SIZE * (x + 1)
+	push	CELL_SIZE * x
 	jmp	_syscall##x
 end macro
 

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -16,7 +16,6 @@ opBI	op_argv, 1, 0	;	( -- a )	Push addr of argv
 end_op
 
 macro scallx x
-	mov	SYSCALL_DSH_REG, [data_stack_here]
 	push	(x + 1)
 	jmp	_syscall##x
 end macro

--- a/stack.inc
+++ b/stack.inc
@@ -5,7 +5,7 @@ data_stack_push:
 stack_push:
 	mov	rdi, [rdx]
 	stosq
-	add	qword [rdx], CELL_SIZE
+	mov	[rdx], rdi
 	
 	ret
 
@@ -51,9 +51,11 @@ data_stack_pop2a:
 	ret
 
 return_stack_push:
-	mov	rdx, return_stack_here
-	jmp	stack_push
+	mov	[RS_REG], rax
+	add	RS_REG, CELL_SIZE
+	ret
 
 return_stack_pop:
-	mov	rdx, return_stack_here
-	jmp	stack_pop
+	sub	RS_REG, CELL_SIZE
+	mov	rax, [RS_REG]
+	ret

--- a/stack.inc
+++ b/stack.inc
@@ -1,47 +1,39 @@
-data_stack_push:
-	mov	rdx, data_stack_here
 
-; expects stack in rdx, value to push in rax
-stack_push:
-	mov	rdi, [rdx]
-	stosq
-	mov	[rdx], rdi
-	
+macro stack_push name, reg
+name##_stack_push:
+	mov	[reg], rax
+	add	reg, CELL_SIZE
 	ret
+end macro
 
-data_stack_pop:
-	mov	rdx, data_stack_here
-
-; expects stack in rdx
-stack_pop:
-	sub	qword [rdx], CELL_SIZE
-	mov	rdx, [rdx]
-	mov	rax, [rdx]
-
+macro stack_pop name, reg
+name##_stack_pop:
+	sub	reg, CELL_SIZE
+	mov	rax, [reg]
 	ret
+end macro
+
+stack_push	data, DS_REG
+stack_pop	data, DS_REG
 
 data_stack_depth:
-	mov	rcx, [data_stack_here]
+	mov	rcx, DS_REG
 	sub	rcx, data_stack
 	shr	ecx, 3
 	
 	ret
 
 data_stack_push2:
-	mov	rdx, data_stack_here
-	mov	rdi, [rdx]
-	mov	[rdi], rcx
-	mov	[rdi + CELL_SIZE], rax
-	add	qword [rdx], (CELL_SIZE * 2)
+	mov	[DS_REG], rcx
+	mov	[DS_REG + CELL_SIZE], rax
+	add	DS_REG, (CELL_SIZE * 2)
 
 	ret
 
 data_stack_pop2:
-	mov	rdx, data_stack_here
-	mov	rsi, [rdx]
-	mov	rax, [rsi - CELL_SIZE]
-	mov	rcx, [rsi - (CELL_SIZE * 2)]
-	sub	qword [rdx], (CELL_SIZE * 2)
+	mov	rax, [DS_REG - CELL_SIZE]
+	mov	rcx, [DS_REG - (CELL_SIZE * 2)]
+	sub	DS_REG, (CELL_SIZE * 2)
 	
 	ret
 
@@ -50,12 +42,5 @@ data_stack_pop2a:
 	xchg	rax, rcx
 	ret
 
-return_stack_push:
-	mov	[RS_REG], rax
-	add	RS_REG, CELL_SIZE
-	ret
-
-return_stack_pop:
-	sub	RS_REG, CELL_SIZE
-	mov	rax, [RS_REG]
-	ret
+stack_push	return, RS_REG
+stack_pop	return, RS_REG

--- a/stack.inc
+++ b/stack.inc
@@ -3,6 +3,7 @@ macro stack_push name, reg
 name##_stack_push:
 	mov	[reg], rax
 	add	reg, CELL_SIZE
+	
 	ret
 end macro
 
@@ -10,6 +11,7 @@ macro stack_pop name, reg
 name##_stack_pop:
 	sub	reg, CELL_SIZE
 	mov	rax, [reg]
+	
 	ret
 end macro
 
@@ -32,14 +34,15 @@ data_stack_push2:
 
 data_stack_pop2:
 	mov	rax, [DS_REG - CELL_SIZE]
-	mov	rcx, [DS_REG - (CELL_SIZE * 2)]
 	sub	DS_REG, (CELL_SIZE * 2)
+	mov	rcx, [DS_REG]
 	
 	ret
 
 data_stack_pop2a:
 	call	data_stack_pop2
 	xchg	rax, rcx
+	
 	ret
 
 stack_push	return, RS_REG


### PR DESCRIPTION
Simpler and should be faster. Frees up 49 bytes in block 0 as well.