### PR TITLE
Dedicate a register to ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ see `tools/bth`.
 
 ## Machine Code Contract
 
-If compiling/executing machine code with BlueVM, take note of the reserved registers:
+If executing machine code with BlueVM, take note of the reserved registers:
 
 | Register | Purpose |
 |----|----|
@@ -183,9 +183,8 @@ Along with the code for BlueVM this repository also contains some tools and exam
 ## TODOs
 
 1. Use more dedicated registers like data/return stack
-   1. ip
-   1. here
    1. opcode handler
+   1. here
 1. Consider phasing out Code Buffer in favor of user specified blocks
    1. here/sethere can be removed
    1. What does this mean for comp/setcomp

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If compiling/executing machine code with BlueVM, take note of the reserved regis
 |----|----|
 | r12 | Top of Data Stack |
 | r13 | Top of Return Stack |
+| r14 | Instruction Pointer |
 
 ## Tools/Examples
 
@@ -181,10 +182,19 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. See about dedicated registers for ip, here like data/return stack
-1. Move boot code to bytecode, or maybe better drop it all together
+1. Use more dedicated registers like data/return stack
+   1. ip
+   1. here
+   1. opcode handler
+1. Consider phasing out Code Buffer in favor of user specified blocks
+   1. here/sethere can be removed
+   1. What does this mean for comp/setcomp
+   1. cx can be removed in favor of setincx
+   1. Remove clitx macros from blasm
+1. Consider phasing out Input Buffer in favor of user specified blocks
+   1. Move boot code to bytecode, or maybe better drop it all together
    1. If dropped, need to change tests that `bluevm < test`
-1. Rename code buffer to output buffer
+   1. Or could just be inlined into the empty default input block?
 1. Get some writing about BlueVM, blasm, bth
 1. Bug: add/remove ops and `make` fails until `make clean`
 1. Bring back a simpiler version of the `blue` language

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -102,6 +102,7 @@ If compiling/executing machine code with BlueVM, take note of the reserved regis
 |----|----|
 | r12 | Top of Data Stack |
 | r13 | Top of Return Stack |
+| r14 | Instruction Pointer |
 
 ## Tools/Examples
 
@@ -123,10 +124,19 @@ Along with the code for BlueVM this repository also contains some tools and exam
 
 ## TODOs
 
-1. See about dedicated registers for ip, here like data/return stack
-1. Move boot code to bytecode, or maybe better drop it all together
+1. Use more dedicated registers like data/return stack
+   1. ip
+   1. here
+   1. opcode handler
+1. Consider phasing out Code Buffer in favor of user specified blocks
+   1. here/sethere can be removed
+   1. What does this mean for comp/setcomp
+   1. cx can be removed in favor of setincx
+   1. Remove clitx macros from blasm
+1. Consider phasing out Input Buffer in favor of user specified blocks
+   1. Move boot code to bytecode, or maybe better drop it all together
    1. If dropped, need to change tests that `bluevm < test`
-1. Rename code buffer to output buffer
+   1. Or could just be inlined into the empty default input block?
 1. Get some writing about BlueVM, blasm, bth
 1. Bug: add/remove ops and `make` fails until `make clean`
 1. Bring back a simpiler version of the `blue` language

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -96,7 +96,7 @@ see `tools/bth`.
 
 ## Machine Code Contract
 
-If compiling/executing machine code with BlueVM, take note of the reserved registers:
+If executing machine code with BlueVM, take note of the reserved registers:
 
 | Register | Purpose |
 |----|----|
@@ -125,9 +125,8 @@ Along with the code for BlueVM this repository also contains some tools and exam
 ## TODOs
 
 1. Use more dedicated registers like data/return stack
-   1. ip
-   1. here
    1. opcode handler
+   1. here
 1. Consider phasing out Code Buffer in favor of user specified blocks
    1. here/sethere can be removed
    1. What does this mean for comp/setcomp

--- a/bluevm.asm
+++ b/bluevm.asm
@@ -5,12 +5,12 @@ BLK_0 = $$ - ELF_HEADERS_SIZE
 
 segment readable writeable executable
 
-instruction_pointer dq input_buffer
 opcode_handler dq opcode_handler_interpret
 
 ; these registers have app lifetime
 DS_REG = r12
 RS_REG = r13
+IP_REG = r14
 
 include "bluevm_defs.inc"
 include "stack.inc"
@@ -43,13 +43,14 @@ read_boot_code:
 entry $
 	mov	DS_REG, data_stack
 	mov	RS_REG, return_stack
+	mov	IP_REG, input_buffer
 	
 	mov	rax, [rsp]
 	mov	[argc], rax
 	lea	rax, [rsp+8]
 	mov	[argv], rax
 	
-	call	read_boot_code	
+	call	read_boot_code
 	call	interpreter
 
 BLK_0_PADDING = VM_CODE_SIZE - ($ - $$)

--- a/interpreter.inc
+++ b/interpreter.inc
@@ -45,11 +45,9 @@ opcode_tbl_entry:
 	ret
 
 interpreter:
-	; TODO: mov byte and inc
-	mov	rsi, IP_REG
 	xor	eax, eax
-	lodsb
-	mov	IP_REG, rsi
+	mov	al, byte [IP_REG]
+	inc	IP_REG
 
 	push	rax
 	call	opcode_tbl_entry

--- a/interpreter.inc
+++ b/interpreter.inc
@@ -19,13 +19,13 @@ opcode_handler_compile:
 	and	ecx, 0xFF
 
 	mov	rdi, [code_buffer_here]
-	mov	rsi, [instruction_pointer]
+	mov	rsi, IP_REG
 	dec	rsi
 
 	rep	movsb
 
 	mov	[code_buffer_here], rdi
-	mov	[instruction_pointer], rsi
+	mov	IP_REG, rsi
 
 	ret
 
@@ -45,10 +45,11 @@ opcode_tbl_entry:
 	ret
 
 interpreter:
-	mov	rsi, [instruction_pointer]
+	; TODO: mov byte and inc
+	mov	rsi, IP_REG
 	xor	eax, eax
 	lodsb
-	mov	[instruction_pointer], rsi
+	mov	IP_REG, rsi
 
 	push	rax
 	call	opcode_tbl_entry

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -125,13 +125,6 @@ _set_post:
 
 	ret
 
-; TODO: maybe can inline now?
-_pre_lit:
-	mov	rsi, IP_REG
-	xor	eax, eax
-
-	ret
-
 _post_lit:
 	call	data_stack_push
 	mov	IP_REG, rsi

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -1,6 +1,6 @@
 
 _call:
-	xchg	[instruction_pointer], rax
+	xchg	IP_REG, rax
 	call	return_stack_push
 
 	ret
@@ -125,15 +125,16 @@ _set_post:
 
 	ret
 
+; TODO: maybe can inline now?
 _pre_lit:
-	mov	rsi, [instruction_pointer]
+	mov	rsi, IP_REG
 	xor	eax, eax
 
 	ret
 
 _post_lit:
 	call	data_stack_push
-	mov	[instruction_pointer], rsi
+	mov	IP_REG, rsi
 
 	ret
 

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -98,7 +98,7 @@ end_op
 
 opNI	op_ret, 1, 0	;	( -- )	Pops value from return stack and sets the instruction pointer
 	call	return_stack_pop
-	mov	[instruction_pointer], rax
+	mov	IP_REG, rax
 	
 	ret
 end_op
@@ -131,7 +131,7 @@ opBI	op_setvarq, 1, 0	;	( q b -- )	Set litq value of var op
 end_op
 
 opNI	op_ip, 1, 0	;	( -- a )	Push location of the instruction pointer
-	mov	rax, [instruction_pointer]
+	mov	rax, IP_REG
 	call	data_stack_push
 
 	ret
@@ -139,7 +139,7 @@ end_op
 
 opNI	op_setip, 1, 0	;	( a -- )	Set the location of the instruction pointer
 	call	data_stack_pop
-	mov	[instruction_pointer], rax
+	mov	IP_REG, rax
 
 	ret
 end_op

--- a/ops_vm.inc
+++ b/ops_vm.inc
@@ -229,32 +229,28 @@ opBI	op_cq, 1, 0	;	( q -- )	Write qword value to and increment here
 	cx	q
 end_op
 
-opNI	op_litb, 2, 0	;	( -- b )	Push next byte from and increment instruction pointer
-	call	_pre_lit
-	lodsb
+macro litx x
+	mov	rsi, IP_REG
+	xor	eax, eax
+	lods##x
 
 	jmp	_post_lit
+end macro
+
+opNI	op_litb, 2, 0	;	( -- b )	Push next byte from and increment instruction pointer
+	litx	b
 end_op
 
 opNI	op_litw, 3, 0	;	( -- w )	Push next word from and increment instruction pointer
-	call	_pre_lit
-	lodsw
-
-	jmp	_post_lit
+	litx	w
 end_op
 
 opNI	op_litd, 5, 0	;	( -- d )	Push next dword from and increment instruction pointer
-	call	_pre_lit
-	lodsd
-
-	jmp	_post_lit
+	litx	d
 end_op
 
 opNI	op_litq, 9, 0	;	( -- q )	Push next qword from and increment instruction pointer
-	call	_pre_lit
-	lodsq
-
-	jmp	_post_lit
+	litx	q
 end_op
 
 ;


### PR DESCRIPTION
Dedicate another register, this time for the instruction pointer. Simpler, should be faster and returns 37 bytes to block 0.