### PR TITLE
Remove support for nested comp/endcomp

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,10 @@ Along with the code for BlueVM this repository also contains some tools and exam
    1. This will help phase out the explict code buffer
    1. Also fix the issue of writing non user code to a block
    1. Nesting comp/endcomp is what prevents simplification
-      1. No need to compile in jumps, manage ip
-      1. comp/endcomp still needed but will just set flags
       1. Will drop the nod to Factor once this is removed
+   1. No need to compile in jumps, manage ip
+      1. Can remove opcode_handler and just have flag
+   1. comp/endcomp still needed but will just set flags
    1. See how things need to work for the Blue Language
       1. Previous versions showed keeoing frontend concerns in the frontend was good
 1. Phase out Code Buffer in favor of user specified blocks

--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ Along with the code for BlueVM this repository also contains some tools and exam
    1. cx can be removed in favor of setincx
    1. Remove clitx macros from blasm
 1. If dst works out, add src for use with atincx, cpincx
+1. Tweak calls
+   1. Rename call to calla
+   1. Rename mccall to callma
+   1. Add callr
+   1. Add callmr
 1. Get some writing about BlueVM, blasm, bth
 1. Bug: add/remove ops and `make` fails until `make clean`
 1. Bring back a simpiler version of the `blue` language

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ _This file is generated from README.md.tmpl_
 
 # BlueVM
 
-Minimalistic 64 bit virtual machine inspired by Forth and Factor. This is the reference implementation for
-x86_64 Linux.
+Minimalistic 64 bit virtual machine inspired by Forth. This is the reference implementation for x86_64 Linux.
 
 The BlueVM aims to:
 
@@ -11,7 +10,6 @@ The BlueVM aims to:
 1. Support execution of any previously compiled machine or bytecode
 1. Provide a minimal set of opcodes that can be extended by the host
 1. Serve as the basis for minimalistic handcrafted applications
-1. Allow the host full control
 1. Bring some fun back into the world
 
 BlueVM bytecode is stored in block sized (1024 byte) files that, by convention, have a `.bs0` (BlueVM Stage 0)
@@ -57,7 +55,7 @@ Hello, World!
 
 The default boot sector reads a block from stdin into Block 6 and `setip`s to that location. A custom boot sector
 can be spliced in to your binary if the default one does not suffice. For example, `tools/bth` reads a file from
-`argv[1]`, runs the supplied tests and produces `TAP` output.
+`argv[1]`, runs the supplied tests and writes `TAP` output.
 
 ## Execution
 
@@ -189,11 +187,9 @@ Along with the code for BlueVM this repository also contains some tools and exam
    1. No implicit `ret`s
    1. This will help phase out the explict code buffer
    1. Also fix the issue of writing non user code to a block
-   1. Nesting comp/endcomp is what prevents simplification
-      1. Will drop the nod to Factor once this is removed
-   1. No need to compile in jumps, manage ip
-      1. Can remove opcode_handler and just have flag
    1. comp/endcomp still needed but will just set flags
+      1. No need to compile in jumps, manage ip
+      1. Can remove opcode_handler
    1. See how things need to work for the Blue Language
       1. Previous versions showed keeoing frontend concerns in the frontend was good
 1. Phase out Code Buffer in favor of user specified blocks

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -1,7 +1,6 @@
 # BlueVM
 
-Minimalistic 64 bit virtual machine inspired by Forth and Factor. This is the reference implementation for
-x86_64 Linux.
+Minimalistic 64 bit virtual machine inspired by Forth. This is the reference implementation for x86_64 Linux.
 
 The BlueVM aims to:
 
@@ -9,7 +8,6 @@ The BlueVM aims to:
 1. Support execution of any previously compiled machine or bytecode
 1. Provide a minimal set of opcodes that can be extended by the host
 1. Serve as the basis for minimalistic handcrafted applications
-1. Allow the host full control
 1. Bring some fun back into the world
 
 BlueVM bytecode is stored in block sized (1024 byte) files that, by convention, have a `.bs0` (BlueVM Stage 0)
@@ -55,7 +53,7 @@ Hello, World!
 
 The default boot sector reads a block from stdin into Block 6 and `setip`s to that location. A custom boot sector
 can be spliced in to your binary if the default one does not suffice. For example, `tools/bth` reads a file from
-`argv[1]`, runs the supplied tests and produces `TAP` output.
+`argv[1]`, runs the supplied tests and writes `TAP` output.
 
 ## Execution
 
@@ -131,11 +129,9 @@ Along with the code for BlueVM this repository also contains some tools and exam
    1. No implicit `ret`s
    1. This will help phase out the explict code buffer
    1. Also fix the issue of writing non user code to a block
-   1. Nesting comp/endcomp is what prevents simplification
-      1. Will drop the nod to Factor once this is removed
-   1. No need to compile in jumps, manage ip
-      1. Can remove opcode_handler and just have flag
    1. comp/endcomp still needed but will just set flags
+      1. No need to compile in jumps, manage ip
+      1. Can remove opcode_handler
    1. See how things need to work for the Blue Language
       1. Previous versions showed keeoing frontend concerns in the frontend was good
 1. Phase out Code Buffer in favor of user specified blocks

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -145,6 +145,11 @@ Along with the code for BlueVM this repository also contains some tools and exam
    1. cx can be removed in favor of setincx
    1. Remove clitx macros from blasm
 1. If dst works out, add src for use with atincx, cpincx
+1. Tweak calls
+   1. Rename call to calla
+   1. Rename mccall to callma
+   1. Add callr
+   1. Add callmr
 1. Get some writing about BlueVM, blasm, bth
 1. Bug: add/remove ops and `make` fails until `make clean`
 1. Bring back a simpiler version of the `blue` language

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -132,9 +132,10 @@ Along with the code for BlueVM this repository also contains some tools and exam
    1. This will help phase out the explict code buffer
    1. Also fix the issue of writing non user code to a block
    1. Nesting comp/endcomp is what prevents simplification
-      1. No need to compile in jumps, manage ip
-      1. comp/endcomp still needed but will just set flags
       1. Will drop the nod to Factor once this is removed
+   1. No need to compile in jumps, manage ip
+      1. Can remove opcode_handler and just have flag
+   1. comp/endcomp still needed but will just set flags
    1. See how things need to work for the Blue Language
       1. Previous versions showed keeoing frontend concerns in the frontend was good
 1. Phase out Code Buffer in favor of user specified blocks

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -91,24 +91,7 @@ op_endcomp:
 
 	call	return_stack_pop
 	mov	OP_REG, rax
-
-	cmp	rax, opcode_handler_interpret
-	je	.outer
 	
-.nested:
-	call	return_stack_pop
-	push	rax
-	
-	mov	rdi, [code_buffer_here]
-	mov	al, op_litq_code
-	stosb
-	pop	rax
-	stosq
-	mov	[code_buffer_here], rdi
-	
-	ret
-
-.outer:
 	call	op_fromr.impl
 	
 	ret

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -82,7 +82,7 @@ op_endcomp:
 	stosb
 	mov	[code_buffer_here], rdi
 
-	; patch the addr for ip! that was compiled in before the compilation
+	; patch the addr for setip that was compiled in before the compilation
 	call	return_stack_pop
 	mov	[rax], rdi
 

--- a/ops_code.inc
+++ b/ops_code.inc
@@ -56,7 +56,6 @@ _atinc_post:
 	ret
 
 op_comp:
-	; TODO: only need to do this if nested
 	mov	rdi, [code_buffer_here]
 	mov	al, op_litq_code
 	stosb
@@ -70,9 +69,7 @@ op_comp:
 	mov	rax, rdi
 	call	return_stack_push
 
-	mov	rax, opcode_handler_compile
-	xchg	OP_REG, rax
-	call	return_stack_push
+	mov	OP_REG, opcode_handler_compile
 
 	pop	rax
 	call	return_stack_push
@@ -89,8 +86,7 @@ op_endcomp:
 	call	return_stack_pop
 	mov	[rax], rdi
 
-	call	return_stack_pop
-	mov	OP_REG, rax
+	mov	OP_REG, opcode_handler_interpret
 	
 	call	op_fromr.impl
 	

--- a/test/call.bla
+++ b/test/call.bla
@@ -3,7 +3,7 @@ include "../tools/bth/tap.inc"
 
 test
 
-litw	'11'
+litw	'03'
 plan
 
 ;
@@ -12,76 +12,6 @@ plan
 
 comp
 	ok
-endcomp
-call
-
-comp
-	comp
-		ok
-	endcomp
-	call
-endcomp
-call
-
-comp
-	comp
-		comp
-			ok
-		endcomp
-		call
-	endcomp
-	call
-endcomp
-call
-
-comp
-	comp
-		comp
-			comp
-				ok
-			endcomp
-			call
-		endcomp
-		call
-	endcomp
-	call
-endcomp
-call
-
-comp
-	comp
-		comp
-			comp
-				comp
-					ok
-				endcomp
-				call
-			endcomp
-			call
-		endcomp
-		call
-	endcomp
-	call
-endcomp
-call
-
-comp
-	comp
-		comp
-			comp
-				comp
-					comp
-						ok
-					endcomp
-					call
-				endcomp
-				call
-			endcomp
-			call
-		endcomp
-		call
-	endcomp
-	call
 endcomp
 call
 
@@ -95,53 +25,7 @@ call
 litb 0x03
 okeq
 
-litb 0x04
-litb 0x05
-comp
-	comp
-		comp
-			add
-		endcomp
-		call
-	endcomp
-	call
-endcomp
-call
-
-litb 0x09
-okeq
-
-litb 0x01
-comp
-	litb 0x03
-	eq
-	comp
-		comp
-			notok
-		endcomp
-		comp
-			ok
-		endcomp
-		ifelse
-	endcomp
-	call
-endcomp
-call
-
 litb	0x09
-blk
-dup
-
-litb	op_ok_code
-setincb
-
-litb	op_ret_code
-setincb
-drop
-
-call
-
-litb	0x05
 blk
 dup
 

--- a/test/extoprt.bla
+++ b/test/extoprt.bla
@@ -7,7 +7,7 @@ litw	'02'
 plan
 
 ;
-; implement assert as extended opcode 0xFF at runtime
+; implement extended opcode 0xFF to add 7 to the top of the stack
 ;
 
 litb	0xFF
@@ -21,22 +21,16 @@ setincb
 
 ; compile and write bytecode address into the opcode table
 comp
-	comp
-		ok
-	endcomp
-	comp
-		notok
-	endcomp
-	ifelse
+	litb	0x07
+	add
 endcomp
 setincq
 drop
 
-; call ext opcode to check that stack depth is 0
-depth
-litb	0x00
-eq
+litb	0x03
 litop	0xFF
+litb	0x0A
+okeq
 
 ;
 ; implement extended opcode 0xFF to add 7 to the top of the stack
@@ -62,7 +56,6 @@ litb	op_ret_code
 setincb
 drop
 
-; call ext opcode to check initial value is 0
 litb	0x03
 litop	0xFF
 litb	0x0A


### PR DESCRIPTION
Starts the simplification of `comp`/`endcomp`, removes support for nesting. Returns 43 bytes to block 0.