### PR TITLE
Factor out some machine code

### DIFF
--- a/blue/kernel.bo.asm
+++ b/blue/kernel.bo.asm
@@ -44,7 +44,7 @@ db	BC_DSP_NL
 db	BC_WORD_DEFINE
 dq	"find"
 db	BC_WORD_INTERP
-dq	"dst>r"
+dq	"last>r"
 db	BC_WORD_INTERP
 dq	"lodsq"
 
@@ -57,7 +57,7 @@ dq	"ifeq"
 db	BC_WORD_INTERP
 dq	"last"
 db	BC_WORD_INTERP
-dq	"r>dst"
+dq	"r>last"
 db	BC_WORD_END
 db	BC_WORD_INTERP
 dq	"then"

--- a/blue/macros.bo.asm
+++ b/blue/macros.bo.asm
@@ -69,15 +69,6 @@ db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
 dq	"writedst"
-if 0
-; mov rdx, rdi
-db	BC_NUM_PUSH
-dq	0x8948
-db	BC_COMMA_W
-db	BC_NUM_PUSH
-dq	0xFA
-db	BC_COMMA_B
-end if
 db	BC_WORD_INTERP
 dq	"rdx"
 db	BC_WORD_INTERP
@@ -85,7 +76,7 @@ dq	"rdi"
 db	BC_WORD_INTERP
 dq	"rex.w"
 db	BC_WORD_INTERP
-dq	"mov/rr"
+dq	"mov"
 
 db	BC_WORD_INTERP
 dq	"rsi="
@@ -193,13 +184,14 @@ db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
 dq	"keep"
-; 48 89 c1                mov    rcx,rax
-db	BC_NUM_PUSH
-dq	0x8948
-db	BC_COMMA_W
-db	BC_NUM_PUSH
-dq	0xC1
-db	BC_COMMA_B
+db	BC_WORD_INTERP
+dq	"rcx"
+db	BC_WORD_INTERP
+dq	"rax"
+db	BC_WORD_INTERP
+dq	"rex.w"
+db	BC_WORD_INTERP
+dq	"mov"
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE

--- a/blue/macros.bo.asm
+++ b/blue/macros.bo.asm
@@ -69,6 +69,7 @@ db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
 dq	"writedst"
+if 0
 ; mov rdx, rdi
 db	BC_NUM_PUSH
 dq	0x8948
@@ -76,6 +77,15 @@ db	BC_COMMA_W
 db	BC_NUM_PUSH
 dq	0xFA
 db	BC_COMMA_B
+end if
+db	BC_WORD_INTERP
+dq	"rdx"
+db	BC_WORD_INTERP
+dq	"rdi"
+db	BC_WORD_INTERP
+dq	"rex.w"
+db	BC_WORD_INTERP
+dq	"mov/rr"
 
 db	BC_WORD_INTERP
 dq	"rsi="
@@ -264,7 +274,7 @@ db	BC_DSP_NL
 db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
-dq	"dst>r"
+dq	"last>r"
 ; 41 54                   push   r12
 db	BC_NUM_PUSH
 dq	0x5441
@@ -272,14 +282,12 @@ db	BC_COMMA_W
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
-dq	"r>dst"
+dq	"r>last"
 ; 41 5c                   pop    r12
 db	BC_NUM_PUSH
 dq	0x5C41
 db	BC_COMMA_W
 db	BC_WORD_END
-
-db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
 dq	"last"
@@ -291,6 +299,8 @@ db	BC_NUM_PUSH
 dq	0xE0
 db	BC_COMMA_B
 db	BC_WORD_END
+
+db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
 dq	"deprev"

--- a/btv/hexnum.bo.asm
+++ b/btv/hexnum.bo.asm
@@ -120,6 +120,7 @@ db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
 dq	"ashex"
+if 0
 ; 48 89 c2                mov    rdx,rax
 db	BC_NUM_PUSH
 dq	0x8948
@@ -127,6 +128,15 @@ db	BC_COMMA_W
 db	BC_NUM_PUSH
 dq	0xC2
 db	BC_COMMA_B
+end if
+db	BC_WORD_INTERP
+dq	"rdx"
+db	BC_WORD_INTERP
+dq	"rax"
+db	BC_WORD_INTERP
+dq	"rex.w"
+db	BC_WORD_INTERP
+dq	"mov"
 db	BC_WORD_RCALL
 dq	"hexstr"
 db	BC_WORD_END

--- a/lib/x86_64/common.bo.asm
+++ b/lib/x86_64/common.bo.asm
@@ -89,17 +89,15 @@ db	BC_COMMA_W
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
+dq	"stosq"
+db	BC_WORD_INTERP
+dq	"rex.w"
+
+db	BC_WORD_DEFINE
 dq	"stosd"
 db	BC_NUM_PUSH
 dq	0xAB
 db	BC_COMMA_B
-db	BC_WORD_END
-
-db	BC_WORD_DEFINE
-dq	"stosq"
-db	BC_NUM_PUSH
-dq	0xAB48
-db	BC_COMMA_W
 db	BC_WORD_END
 
 db	BC_DSP_NL

--- a/lib/x86_64/common.bo.asm
+++ b/lib/x86_64/common.bo.asm
@@ -1,6 +1,30 @@
 include "bc.inc"
 
 db	BC_WORD_DEFINE
+dq	"rex.w"
+db	BC_WORD_INTERP
+dq	"rex"
+db	BC_WORD_INTERP
+dq	".w"
+db	BC_OR
+db	BC_COMMA_B
+db	BC_WORD_END
+
+db	BC_DSP_NL
+
+db	BC_WORD_DEFINE
+dq	"mov/rr"
+db	BC_NUM_PUSH
+dq	0x89
+db	BC_COMMA_B
+db	BC_WORD_INTERP
+dq	"/r"
+db	BC_COMMA_B
+db	BC_WORD_END
+
+db	BC_DSP_NL
+
+db	BC_WORD_DEFINE
 dq	"xor"
 db	BC_NUM_PUSH
 dq	0x31

--- a/lib/x86_64/common.bo.asm
+++ b/lib/x86_64/common.bo.asm
@@ -13,7 +13,7 @@ db	BC_WORD_END
 db	BC_DSP_NL
 
 db	BC_WORD_DEFINE
-dq	"mov/rr"
+dq	"mov"
 db	BC_NUM_PUSH
 dq	0x89
 db	BC_COMMA_B

--- a/lib/x86_64/encoding.bo.asm
+++ b/lib/x86_64/encoding.bo.asm
@@ -2,24 +2,32 @@ include "bc.inc"
 
 db	BC_WORD_DEFINE
 dq	"eax"
+db	BC_WORD_DEFINE
+dq	"rax"
 db	BC_NUM_PUSH
 dq	0x00
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
 dq	"edx"
+db	BC_WORD_DEFINE
+dq	"rdx"
 db	BC_NUM_PUSH
 dq	0x02
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
 dq	"esi"
+db	BC_WORD_DEFINE
+dq	"rsi"
 db	BC_NUM_PUSH
 dq	0x06
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
 dq	"edi"
+db	BC_WORD_DEFINE
+dq	"rdi"
 db	BC_NUM_PUSH
 dq	0x07
 db	BC_WORD_END
@@ -41,6 +49,18 @@ db	BC_SHL
 db	BC_OR
 db	BC_WORD_INTERP
 dq	"/0"
+db	BC_WORD_END
+
+db	BC_WORD_DEFINE
+dq	"rex"
+db	BC_NUM_PUSH
+dq	0x40
+db	BC_WORD_END
+
+db	BC_WORD_DEFINE
+dq	".w"
+db	BC_NUM_PUSH
+dq	0x08
 db	BC_WORD_END
 
 db	BC_DSP_NL

--- a/lib/x86_64/encoding.bo.asm
+++ b/lib/x86_64/encoding.bo.asm
@@ -9,6 +9,14 @@ dq	0x00
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
+dq	"ecx"
+db	BC_WORD_DEFINE
+dq	"rcx"
+db	BC_NUM_PUSH
+dq	0x01
+db	BC_WORD_END
+
+db	BC_WORD_DEFINE
 dq	"edx"
 db	BC_WORD_DEFINE
 dq	"rdx"


### PR DESCRIPTION
Start of words for rex prefixes and mov. Also fixed a wrongly named word.