### PR TITLE
Change default display for BC_SHL and BC_OR

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Opcode numbers are defined in `bc.inc` and are subject to change.
 | `dup` | Duplicate the top item on the data stack |
 | `+` | Pop two data stack items, add them and push the result |
 | `-` | Pop two data stack items, subtract them and push the result |
-| `or` | Pop two data stack items, logical or them and push the result |
+| `|` | Pop two data stack items, logical or them and push the result |
 | `<<` | Pop two data stack items, shift the second left the number of times in the first and push the result |
 | `$` | Push assemble time address of the current location in the output buffer |
 | `$*` | Push run time address of the current location in the output buffer |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Opcode numbers are defined in `bc.inc` and are subject to change.
 | `+` | Pop two data stack items, add them and push the result |
 | `-` | Pop two data stack items, subtract them and push the result |
 | `or` | Pop two data stack items, logical or them and push the result |
-| `shl` | Pop two data stack items, shift the second left the number of times in the first and push the result |
+| `<<` | Pop two data stack items, shift the second left the number of times in the first and push the result |
 | `$` | Push assemble time address of the current location in the output buffer |
 | `$*` | Push run time address of the current location in the output buffer |
 | `$>` | Push assemble time address of the output buffer's start |

--- a/lib/bc/view/ops.bo.asm
+++ b/lib/bc/view/ops.bo.asm
@@ -135,7 +135,7 @@ dq	"ds_or"
 db	BC_WORD_RCALL
 dq	"vizop"
 db	BC_WORD_INTERP
-dq	'"or"'
+dq	'"|"'
 db	BC_WORD_END
 
 db	BC_DSP_NL

--- a/lib/bc/view/ops.bo.asm
+++ b/lib/bc/view/ops.bo.asm
@@ -145,7 +145,7 @@ dq	"ds_shl"
 db	BC_WORD_RCALL
 dq	"vizop"
 db	BC_WORD_INTERP
-dq	'"shl"'
+dq	'"<<"'
 db	BC_WORD_END
 
 db	BC_DSP_NL

--- a/viewer/macros.bo.asm
+++ b/viewer/macros.bo.asm
@@ -127,15 +127,11 @@ dq	"wout"
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
-dq	'"shl"'
+dq	'"<<"'
 db	BC_NUM_PUSH
-dq	"sh"
+dq	"<<"
 db	BC_WORD_INTERP
 dq	"wout"
-db	BC_NUM_PUSH
-dq	"l"
-db	BC_WORD_INTERP
-dq	"bout"
 db	BC_WORD_END
 
 db	BC_DSP_NL

--- a/viewer/macros.bo.asm
+++ b/viewer/macros.bo.asm
@@ -119,11 +119,11 @@ dq	"bout"
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE
-dq	'"or"'
+dq	'"|"'
 db	BC_NUM_PUSH
-dq	"or"
+dq	"|"
 db	BC_WORD_INTERP
-dq	"wout"
+dq	"bout"
 db	BC_WORD_END
 
 db	BC_WORD_DEFINE


### PR DESCRIPTION
The old default display names of `shl` and `or` conflicted with the style of defining words to match x86 instructions, so changing their default display to `|` and `<<`.