### PR TITLE
First drop of aarch64 port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 obj
 scratch*
+.env

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 FASM ?= $(shell which fasm)
 
 BLUE_BC_ASMS = $(wildcard \
+	lib/aarch64/elf/*.bo.asm \
 	lib/bc/*.bo.asm \
 	lib/bc/view/*.bo.asm \
 	lib/bc/view/ansi/*.bo.asm \
@@ -11,6 +12,7 @@ BLUE_BC_ASMS = $(wildcard \
 	blue/*.bo.asm \
 	bnc/*.bo.asm \
 	viewer/*.bo.asm \
+	examples/aarch64/exit/*.bo.asm \
 	examples/exit/*.bo.asm \
 	examples/helloworld/*.bo.asm \
 	examples/readme/*.bo.asm \
@@ -26,6 +28,7 @@ TOOLS = bin/bnc bin/btv
 
 EXAMPLES = \
 	bin/examples/exit \
+	bin/examples/aarch64/exit \
 	bin/examples/helloworld
 
 .PHONY: all clean
@@ -96,6 +99,12 @@ obj/examples/exit.b: \
 	obj/lib/x86_64/linux.bo \
 	obj/lib/elf/headers.min.bo \
 	obj/examples/exit/exit.bo \
+	obj/lib/elf/fin.min.bo \
+
+obj/examples/aarch64/exit.b: \
+	obj/lib/elf/headers.min.bo \
+	obj/lib/aarch64/elf/headers.min.patch.bo \
+	obj/examples/aarch64/exit/exit.bo \
 	obj/lib/elf/fin.min.bo \
 
 obj/examples/helloworld.b: \

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Some links that may help fill in some back story/knowledge in no particular orde
 1. [POL](https://colorforth.github.io/POL.htm)
 1. [x86 Instruction Reference](https://www.felixcloutier.com/x86/)
 1. [x86-64 Registers](https://wiki.osdev.org/CPU_Registers_x86-64)
+1. [arm64 Syscall Table](https://arm64.syscall.sh/)
+1. [armv8 Tutorial](https://mariokartwii.com/armv8/)
+1. [a64 Instructions](https://www.scs.stanford.edu/~zyedidia/arm64/index.html)
 
 ## TODOs
 
@@ -211,3 +214,7 @@ Some links that may help fill in some back story/knowledge in no particular orde
 
 1. Factor hexnum more
 1. That trailing space that looks like a leading space issue
+
+### aarch64
+
+1. TCO once more testing has been done

--- a/aarch64-linux-bootstrap.asm
+++ b/aarch64-linux-bootstrap.asm
@@ -1,0 +1,343 @@
+
+processor cpu64_v8
+code64
+
+format ELF64 executable
+
+segment readable writeable executable
+
+magic:
+.name:	dw "blue"
+.ver:	dw 5
+
+CELL_SIZE = 8
+DICT_ENTRY_SIZE = CELL_SIZE * 3
+DICT_SIZE = DICT_ENTRY_SIZE * 256
+DST_SIZE = 8192
+SRC_SIZE = 8192
+
+DS_SIZE = CELL_SIZE * 16
+DS_MASK = DS_SIZE - 1
+DS_BASE = $ - DS_SIZE
+
+K_ORG = DS_BASE
+
+assert DS_SIZE and DS_MASK = 0
+assert DS_BASE and DS_MASK = 0
+
+REG_LVL equ w10
+REG_SRC equ x11
+REG_DST equ x12
+REG_DSTB equ x13
+REG_LAST equ x14
+REG_DS equ x15
+
+BL_MASK dw 0x97 shl 24
+B_OFFSET_MASK dw not (0xFF shl 24)
+
+;;; kernel
+
+ds_push:
+	str	x9, [REG_DS], 8
+	and	REG_DS, REG_DS, DS_MASK
+	orr	REG_DS, REG_DS, DS_BASE
+_ret:
+	ret
+
+ds_push2:
+_pre_rcall:
+	str	x30, [sp, -16]!
+	bl	ds_push
+_post_rcall:
+	ldr	x30, [sp], 16
+	mov	x9, x8
+	b	ds_push
+
+ds_pop:
+	sub	REG_DS, REG_DS, CELL_SIZE
+	and	REG_DS, REG_DS, DS_MASK
+	orr	REG_DS, REG_DS, DS_BASE
+	ldr	x9, [REG_DS]
+	ret
+
+ds_pop2:
+	mov	x0, x30
+	bl	ds_pop
+	mov	x8, x9
+	mov	x30, x0
+	b	ds_pop
+
+find:
+	str	REG_LAST, [sp, -16]!
+	ldr	x9, [REG_SRC], 8
+
+.check:
+	ldr	x8, [REG_LAST]
+	cmp	x9, x8
+	b.ne	.prev
+	
+	mov	x9, REG_LAST
+	ldr	REG_LAST, [sp], 16
+	ret
+
+.prev:
+	sub	REG_LAST, REG_LAST, DICT_ENTRY_SIZE
+	b	.check
+
+xt:
+	mov	x0, x30
+	bl	find
+	mov	x30, x0
+	ldr	x8, [x9, CELL_SIZE]
+	mov	x9, x8
+	ret
+
+;;; opcode handlers
+
+fin:
+	mov	x0, 1
+	mov	x1, REG_DSTB
+	sub	x2, REG_DST, REG_DSTB
+	mov	w8, 64
+	svc	0
+
+	mov	x0, 11
+	mov	w8, 93
+	svc	0
+
+word_define:
+	ldr	x9, [REG_SRC], 8
+	; TODO: think these two can be combined into a !
+	add	REG_LAST, REG_LAST, DICT_ENTRY_SIZE
+	str	x9, [REG_LAST]
+	str	REG_DST, [REG_LAST, CELL_SIZE]
+	str	REG_SRC, [REG_LAST, (CELL_SIZE * 2)]	
+	b	next
+
+word_end:
+	cmp	REG_LVL, 0
+	b.eq	.top_level
+
+	sub	REG_LVL, REG_LVL, 1
+	ldr	REG_SRC, [sp], 16
+	b	.done
+
+.top_level:
+	; TODO: cmp REG_DST - 4 and BL_MASK == BL_MASK
+	; TODO: b.ne
+	b	.cret
+	; TODO: flip bit 31 (i think is all) of REG_DST - 4
+	; TODO: REG_DST - 8 is nop (clear _pre_rcall)
+	; TODO: sub 4 from REG_DST to drop _post_rcall
+	b	.done
+
+.cret:
+	ldr	w9, _ret
+	str	w9, [REG_DST], 4
+
+.done:
+	b	next
+
+word_ccall:
+	bl	xt
+	br	x9
+	b	next
+
+word_rcall:
+	ldr	w9, _pre_rcall
+	str	w9, [REG_DST], 4
+	
+	bl	xt
+	;(0x97 shl 24) or (((xt - dst) shr 2) and (not (0xFF shl 24))) 
+	sub	x9, x9, REG_DST
+	lsr	x9, x9, 2
+	ldr	w8, B_OFFSET_MASK
+	and	w9, w9, w8
+	ldr	w8, BL_MASK
+	orr	w9, w9, w8
+	str	w9, [REG_DST], 4
+	
+	ldr	w9, _post_rcall
+	str	w9, [REG_DST], 4
+	b	next
+
+word_interp:
+	bl	find
+	str	REG_SRC, [sp, -16]!
+	add	REG_LVL, REG_LVL, 1
+	ldr	REG_SRC, [x9, (CELL_SIZE * 2)]
+	b	next
+
+word_caddr:
+	bl	xt
+	bl	ds_push
+	b	next
+
+word_raddr:
+	bl	xt
+raddr:
+	sub	x9, x9, REG_DSTB
+	add	x9, x9, K_ORG
+	bl	ds_push
+	b	next
+
+num_comp:
+	ldr	x9, [REG_SRC], 8
+	str	x9, [REG_DST], 8
+	b	next
+	
+num_push:
+	ldr	x9, [REG_SRC], 8
+	bl	ds_push
+	b	next
+
+tor:
+	bl	ds_pop
+	str	x9, [sp, -16]!
+	b	next
+
+fromr:
+	ldr	x9, [sp], 16
+	bl	ds_push
+	b	next
+
+swap:
+	bl	ds_pop2
+	mov	x7, x9
+	mov	x9, x8
+	mov	x8, x7
+	bl	ds_push2
+	b	next
+
+k_dup:
+	bl	ds_pop
+	bl	ds_push
+	bl	ds_push
+	b	next
+
+k_add:
+	bl	ds_pop2
+	add	x9, x9, x8
+	bl	ds_push
+	b	next
+
+k_sub:
+	bl	ds_pop2
+	sub	x9, x9, x8
+	bl	ds_push
+	b	next
+
+k_or:
+	bl	ds_pop2
+	orr	x9, x9, x8
+	bl	ds_push
+	b	next
+
+k_shl:
+	bl	ds_pop2
+	lsl	x9, x9, x8
+	bl	ds_push
+	b	next
+
+dollar_caddr:
+	mov	x9, REG_DST
+	bl	ds_push
+	b	next
+
+dollar_raddr:
+	mov	x9, REG_DST
+	b	raddr
+
+dst_base:
+	mov	x9, REG_DSTB
+	bl	ds_push
+	b	next
+
+dst_base_set:
+	bl	ds_pop
+	mov	REG_DSTB, x9
+	b	next
+
+set_b:
+	bl	ds_pop2
+	strb	w9, [x8]
+	b	next
+
+set:
+	bl	ds_pop2
+	str	x9, [x8]
+	b	next
+
+fetch:
+	bl	ds_pop
+	ldr	x9, [x9]
+	bl	ds_push
+	b	next
+
+comma_b:
+	bl	ds_pop
+	strb	w9, [REG_DST], 1
+	b	next
+
+comma_w:
+	bl	ds_pop
+	strh	w9, [REG_DST], 2
+	b	next
+
+comma_d:
+	bl	ds_pop
+	str	w9, [REG_DST], 4
+	b	next
+
+comma:
+	bl	ds_pop
+	str	x9, [REG_DST], 8
+	b	next
+
+dsp_nl:
+	b	next
+
+;;; interpreter
+
+next:
+	ldrb	w9, [REG_SRC], 1
+	lsl	w9, w9, 3
+	adr	x8, bc_tbl
+	add	x8, x8, x9
+	ldr	x9, [x8]
+	br	x9
+
+;;; main
+
+entry $
+	mov	x0, 0
+	adr	x1, _src
+	mov	x2, SRC_SIZE
+	mov	w8, 63
+	svc	0
+
+	adr	REG_SRC, _src
+	adr	REG_DSTB, _dst
+	adr	REG_DST, _dst
+	mov	REG_DS, DS_BASE
+	adr	REG_LAST, _dict
+	sub	REG_LAST, REG_LAST, DICT_ENTRY_SIZE
+	
+	b	next
+
+;;; opcode table
+
+bc_tbl:
+dd	fin
+dd	word_define, word_end, word_ccall, word_rcall, word_interp, word_caddr, word_raddr
+dd	num_comp, num_push
+dd	tor, fromr, swap, k_dup, k_add, k_sub, k_or, k_shl
+dd	dollar_caddr, dollar_raddr, dst_base, dst_base_set
+dd	set_b, set, fetch, comma_b, comma_w, comma_d, comma
+dd	dsp_nl
+
+;;; reserved
+
+_dict rb DICT_SIZE
+_dst rb DST_SIZE
+_src rb SRC_SIZE

--- a/aarch64.mk
+++ b/aarch64.mk
@@ -1,0 +1,21 @@
+
+FASM ?= $(shell which fasmarm)
+
+ARCH_PREFIX = aarch64-linux-
+
+BOOTSTRAP_ASM = $(ARCH_PREFIX)bootstrap.asm
+BOOTSTRAP = $(BOOTSTRAP_ASM:%.asm=bin/%)
+
+.PHONY: all scp
+
+all: $(BOOTSTRAP)
+
+# TODO: common.mk
+bin:
+	mkdir $@
+
+$(BOOTSTRAP): $(BOOTSTRAP_ASM) $(FASM) | bin
+	$(FASM) $< $@
+
+scp: $(BOOTSTRAP)
+	scp $(BOOTSTRAP) $(BLUE_AARCH64_HOST):$(BLUE_AARCH64_PATH)

--- a/examples/aarch64/exit/exit.bo.asm
+++ b/examples/aarch64/exit/exit.bo.asm
@@ -1,0 +1,15 @@
+include "bc.inc"
+
+db	BC_NUM_PUSH
+dq	0xD280'0160
+db	BC_COMMA_D
+
+db	BC_NUM_PUSH
+dq	0x5280'0BA8
+db	BC_COMMA_D
+
+db	BC_NUM_PUSH
+dq	0xD400'0001
+db	BC_COMMA_D
+
+db	BC_DSP_NL

--- a/lib/aarch64/elf/headers.min.patch.bo.asm
+++ b/lib/aarch64/elf/headers.min.patch.bo.asm
@@ -1,0 +1,25 @@
+include "bc.inc"
+
+db	BC_DSP_NL
+
+db	BC_NUM_PUSH
+dq	0xB7
+
+db	BC_WORD_CADDR
+dq	"elfhdrs"
+db	BC_NUM_PUSH
+dq	0x12
+db	BC_ADD
+
+db	BC_SET_B
+
+db	BC_NUM_PUSH
+dq	0x05
+
+db	BC_WORD_CADDR
+dq	"elfhdrs"
+db	BC_NUM_PUSH
+dq	0x33
+db	BC_ADD
+
+db	BC_SET_B


### PR DESCRIPTION
First drop of the port to `aarch64`, uses `fasmarm` to cross compile. Bootstrap compiler passes the tests and builds a very basic exit example that runs properly. TCO is still a TODO. Need to flesh out more things and understand encoding more for aarch64 but its a start.